### PR TITLE
fix: re-reported v1.4.8 issues (folder export, folder Run, Win shortcut, mac update)

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -10,9 +10,15 @@
 ; freshly-installed exe.
 ;
 ; macrocustomInstall fires inside the install section, after files are
-; written but before electron-builder's shortcut creation, so deleting
-; first / creating after produces a single fresh shortcut without the
-; orphan-pointing-at-old-version problem.
+; written. We can't rely on electron-builder's own shortcut block running (or
+; running after us) — users on v1.4.7/1.4.8 reported a finished install with NO
+; Start Menu or Desktop shortcut, so the only launch point was re-running the
+; .exe (#33). To make a launch point GUARANTEED regardless of the builder's
+; conditional shortcut logic or macro ordering, we delete any stale shortcuts
+; and then explicitly CreateShortCut ourselves against the freshly-installed
+; exe. If electron-builder also creates them it just overwrites with an
+; identical target; if it doesn't, ours remain — either way the app is
+; launchable from a shortcut after install.
 ; ---------------------------------------------------------------------------
 
 !macro customInstall
@@ -33,9 +39,12 @@
   Delete "$SMPROGRAMS\Testnizer\Testnizer.lnk"
   RMDir  "$SMPROGRAMS\Testnizer"
 
-  ; Restore the current-user context for electron-builder's own shortcut
-  ; creation logic (perMachine:false in package.json).
+  ; Restore the current-user context (perMachine:false in package.json) and
+  ; create the shortcuts ourselves so a launch point always exists. ${INSTDIR}
+  ; holds the just-extracted app; the exe is named after productName.
   SetShellVarContext current
+  CreateShortCut "$SMPROGRAMS\Testnizer.lnk" "$INSTDIR\Testnizer.exe" "" "$INSTDIR\Testnizer.exe" 0
+  CreateShortCut "$DESKTOP\Testnizer.lnk" "$INSTDIR\Testnizer.exe" "" "$INSTDIR\Testnizer.exe" 0
 !macroend
 
 !macro customUnInstall

--- a/src/main/ipc/save.handler.ts
+++ b/src/main/ipc/save.handler.ts
@@ -94,6 +94,12 @@ interface FolderExport {
   folders: Record<string, unknown>[]
   endpoints: Record<string, unknown>[]
   endpointCases: Record<string, unknown>[]
+  // Ad-hoc saved requests live in their own table (`saved_requests`), separate
+  // from the structured `endpoints`. The full project export already carried
+  // them; a folder export that only collected `endpoints` silently dropped
+  // every saved request, so a collection made of saved requests round-tripped
+  // as an empty folder (#32). Optional for backward-compat with older files.
+  savedRequests?: Record<string, unknown>[]
 }
 
 // ─── Test Suite Export Format (snapshot model) ──────────────────
@@ -551,6 +557,7 @@ function collectFolderTree(rootFolderId: string): {
   folders: Record<string, unknown>[]
   endpoints: Record<string, unknown>[]
   endpointCases: Record<string, unknown>[]
+  savedRequests: Record<string, unknown>[]
 } {
   const db = getDb()
 
@@ -558,7 +565,7 @@ function collectFolderTree(rootFolderId: string): {
     | Record<string, unknown>
     | undefined
   if (!rootFolder) {
-    return { folders: [], endpoints: [], endpointCases: [] }
+    return { folders: [], endpoints: [], endpointCases: [], savedRequests: [] }
   }
 
   // Recursively gather all descendant folder IDs (BFS)
@@ -590,11 +597,18 @@ function collectFolderTree(rootFolderId: string): {
       .all(...endpointIds) as Record<string, unknown>[]
   }
 
-  return { folders, endpoints, endpointCases }
+  // Saved requests (ad-hoc requests dropped into the collection) live in a
+  // separate table from `endpoints`; collect them too or the folder export is
+  // lossy for any collection that holds saved requests (#32).
+  const savedRequests = db
+    .prepare(`SELECT * FROM saved_requests WHERE folder_id IN (${ph})`)
+    .all(...folderIds) as Record<string, unknown>[]
+
+  return { folders, endpoints, endpointCases, savedRequests }
 }
 
 export function exportFolderData(folderId: string): FolderExport {
-  const { folders, endpoints, endpointCases } = collectFolderTree(folderId)
+  const { folders, endpoints, endpointCases, savedRequests } = collectFolderTree(folderId)
   return {
     version: '1.0.0',
     exportedAt: Date.now(),
@@ -603,6 +617,7 @@ export function exportFolderData(folderId: string): FolderExport {
     folders,
     endpoints,
     endpointCases,
+    savedRequests,
   }
 }
 
@@ -621,9 +636,11 @@ export function importFolderData(
   // ID remapping: oldId → newId
   const folderIdMap = new Map<string, string>()
   const endpointIdMap = new Map<string, string>()
+  const savedReqIdMap = new Map<string, string>()
 
   for (const f of data.folders) folderIdMap.set(f.id as string, randomUUID())
   for (const e of data.endpoints) endpointIdMap.set(e.id as string, randomUUID())
+  for (const s of data.savedRequests || []) savedReqIdMap.set(s.id as string, randomUUID())
 
   const insertFolder = db.prepare(
     `INSERT INTO folders (id, project_id, parent_id, name, sort_order) VALUES (?, ?, ?, ?, ?)`,
@@ -635,6 +652,10 @@ export function importFolderData(
   const insertCase = db.prepare(
     `INSERT INTO endpoint_cases (id, endpoint_id, name, params, headers, body, auth, assertions, is_default, created_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  )
+  const insertSaved = db.prepare(
+    `INSERT INTO saved_requests (id, project_id, folder_id, name, protocol, method, url, params, headers, body, auth, pre_script, post_script, assertions, metadata, sort_order, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   )
 
   const tx = db.transaction(() => {
@@ -699,10 +720,45 @@ export function importFolderData(
         (c.created_at as number) || now,
       )
     }
+
+    // Saved requests — remap id + folder_id like endpoints so a folder export
+    // built from saved requests round-trips losslessly (#32). branch_id is
+    // omitted (defaults to NULL = shared), mirroring the project importer.
+    for (const s of data.savedRequests || []) {
+      const newId = savedReqIdMap.get(s.id as string) as string
+      const oldFolderId = s.folder_id as string | null
+      const newFolderId =
+        oldFolderId && folderIdMap.has(oldFolderId)
+          ? (folderIdMap.get(oldFolderId) as string)
+          : null
+      insertSaved.run(
+        newId,
+        projectId,
+        newFolderId,
+        s.name,
+        s.protocol || 'http',
+        s.method ?? null,
+        s.url ?? null,
+        s.params ?? null,
+        s.headers ?? null,
+        s.body ?? null,
+        s.auth ?? null,
+        s.pre_script ?? null,
+        s.post_script ?? null,
+        s.assertions ?? null,
+        s.metadata ?? null,
+        s.sort_order ?? 0,
+        (s.created_at as number) || now,
+        now,
+      )
+    }
   })
   tx()
 
-  return { foldersImported: folderIdMap.size, endpointsImported: endpointIdMap.size }
+  return {
+    foldersImported: folderIdMap.size,
+    endpointsImported: endpointIdMap.size + savedReqIdMap.size,
+  }
 }
 
 // ─── Test Suite Export / Import (v1.3+ snapshot model) ─────────

--- a/src/renderer/components/modals/UpdateModal.tsx
+++ b/src/renderer/components/modals/UpdateModal.tsx
@@ -35,7 +35,13 @@ function resolveSanitize(): (input: string, opts: unknown) => string {
 const sanitizeHtml = resolveSanitize()
 import { useUpdaterStore } from '../../stores/updater.store'
 import { useTranslation } from '../../lib/i18n'
+import { isMac } from '../../lib/platform'
 import Modal from '../shared/Modal'
+
+// Where users land to grab a build by hand. macOS ad-hoc/unsigned builds can't
+// self-install (electron-updater fails the code-signature check), so on macOS
+// this is the *primary* update path, not just an error fallback (#34).
+const DOWNLOAD_PAGE = 'https://www.testnizer.com/download/'
 
 export default function UpdateModal() {
   const show = useUIStore((s) => s.showUpdateModal)
@@ -162,6 +168,11 @@ function StatusContent({
               />
             </div>
           )}
+          {isMac() && (
+            <span className="text-center text-sm text-[var(--muted)]">
+              {t('update.macAutoUnavailable')}
+            </span>
+          )}
         </>
       )
     case 'downloading':
@@ -234,6 +245,22 @@ function UpdateActions({
     case 'downloading':
       return null
     case 'available':
+      // macOS builds are ad-hoc/unsigned and electron-updater can't self-
+      // install them — the in-app "Download & Install" path always ends in a
+      // code-signature error (#34). Send macOS users straight to the manual
+      // download instead of letting them hit that dead end.
+      if (isMac()) {
+        return (
+          <a
+            href={DOWNLOAD_PAGE}
+            target="_blank"
+            rel="noreferrer"
+            className="cursor-pointer rounded-[7px] border-none bg-[var(--accent)] px-[18px] py-[7px] font-semibold text-white no-underline transition-colors hover:opacity-90"
+          >
+            {t('update.downloadManually')}
+          </a>
+        )
+      }
       return (
         <button
           type="button"

--- a/src/renderer/components/sidebar/TreeView.tsx
+++ b/src/renderer/components/sidebar/TreeView.tsx
@@ -19,6 +19,7 @@ import TreeNodeComponent, { type DragPayload, type DropPosition } from './TreeNo
 import DeleteConfirmDialog from '../modals/DeleteConfirmDialog'
 import { toast } from '../../lib/toast'
 import { t } from '../../lib/i18n'
+import { openFolderRunner } from '../../lib/open-runner-tab'
 
 // Re-alias for flattenTree signature
 type TreeNode = TreeNodeType
@@ -490,20 +491,12 @@ export default function TreeView() {
     [refreshTree],
   )
 
-  const openTab = useTabsStore((s) => s.openTab)
-
-  const handleRunFolder = useCallback(
-    (node: TreeNode) => {
-      const tabId = 'runner-' + node.id
-      openTab({
-        id: tabId,
-        name: 'Runner',
-        protocol: 'runner',
-        folderId: node.id,
-      })
-    },
-    [openTab],
-  )
+  const handleRunFolder = useCallback((node: TreeNode) => {
+    // Open the runner AND switch to the Tests page where it renders — without
+    // the page switch the tab opened but stayed hidden behind the APIs view, so
+    // right-click → Run looked like a no-op (#39).
+    openFolderRunner(node.id, node.label)
+  }, [])
 
   const handleExport = useCallback(
     async (node: TreeNode) => {

--- a/src/renderer/lib/i18n.ts
+++ b/src/renderer/lib/i18n.ts
@@ -786,6 +786,8 @@ const translations: Record<Locale, Record<string, string>> = {
     'update.error': 'Update check failed',
     'update.retry': 'Retry',
     'update.downloadManually': 'Download the latest version manually',
+    'update.macAutoUnavailable':
+      'Automatic install is not available for this macOS build. Download the new version manually and replace the app.',
     'update.releaseNotes': 'Release Notes',
     'update.version': 'Version',
 
@@ -2245,6 +2247,8 @@ const translations: Record<Locale, Record<string, string>> = {
     'update.error': 'Guncelleme kontrolu basarisiz',
     'update.retry': 'Tekrar Dene',
     'update.downloadManually': 'En son sürümü manuel indir',
+    'update.macAutoUnavailable':
+      'Bu macOS sürümü için otomatik kurulum kullanılamıyor. Yeni sürümü manuel indirip uygulamayı değiştirin.',
     'update.releaseNotes': 'Surum Notlari',
     'update.version': 'Surum',
 

--- a/src/renderer/lib/open-runner-tab.ts
+++ b/src/renderer/lib/open-runner-tab.ts
@@ -4,6 +4,7 @@
 // so report data and the active state stay consistent.
 
 import { useTabsStore } from '../stores/tabs.store'
+import { useUIStore } from '../stores/ui.store'
 
 const RUNNER_TAB_ID = 'runner-main'
 
@@ -26,4 +27,25 @@ export function openOrReuseRunnerTab(
   } else {
     tabsApi.openTab({ id: tabId, name: tabName, protocol: 'runner', sessionKey })
   }
+}
+
+/**
+ * Open (or re-focus) a runner tab scoped to a specific APIs-tree folder and
+ * navigate to the page the runner renders on.
+ *
+ * A runner tab `tabBelongsToPage` the **Tests** page (sidebar-pages.ts), so a
+ * runner opened from the APIs sidebar becomes the active tab but stays hidden
+ * behind the APIs view — the Workbench treats the off-page active tab as absent
+ * and shows the APIs welcome instead. That made the folder context-menu "Run"
+ * look like a no-op (#39). Switching the sidebar page here surfaces the runner.
+ */
+export function openFolderRunner(folderId: string, folderName?: string): void {
+  const tabsApi = useTabsStore.getState()
+  tabsApi.openTab({
+    id: 'runner-' + folderId,
+    name: folderName || 'Runner',
+    protocol: 'runner',
+    folderId,
+  })
+  useUIStore.getState().setActiveSidebarPage('tests')
 }

--- a/tests/main/project-export-import-roundtrip.test.ts
+++ b/tests/main/project-export-import-roundtrip.test.ts
@@ -748,4 +748,56 @@ describe('Folder export → import round-trip', () => {
     expect(newEndpoint.method).toBe('POST')
     expect(newEndpoint.path).toBe('/users')
   })
+
+  it('preserves saved requests inside the folder (regression #32)', () => {
+    // A collection made of *saved requests* (ad-hoc requests dropped into a
+    // folder, stored in `saved_requests`, not `endpoints`) used to round-trip
+    // as an empty folder: the folder export only collected `endpoints`, so
+    // every saved request was silently dropped.
+    const ids = seedRichProject()
+    const savedInFolder = randomUUID()
+    testDb
+      .prepare(
+        `INSERT INTO saved_requests
+           (id, project_id, folder_id, name, protocol, method, url, params, headers, body,
+            auth, pre_script, post_script, assertions, metadata, sort_order, created_at, updated_at)
+         VALUES (?, ?, ?, 'Ping', 'http', 'GET', 'https://api.example/ping',
+                 '[]', '[]', '', NULL, '', '', '[]', NULL, 0, ?, ?)`,
+      )
+      .run(savedInFolder, SOURCE_PID, ids.childFolderId, Date.now(), Date.now())
+
+    const exported = exportFolderData(ids.rootFolderId)
+    // The folder export must now carry the saved request that lives in it.
+    expect(exported.savedRequests?.length).toBe(1)
+    expect(exported.savedRequests?.[0].name).toBe('Ping')
+
+    const destParent = randomUUID()
+    testDb
+      .prepare(
+        `INSERT INTO folders (id, project_id, parent_id, name, sort_order) VALUES (?, ?, NULL, 'Graft', 2)`,
+      )
+      .run(destParent, SOURCE_PID)
+
+    const out = importFolderData(exported, SOURCE_PID, destParent)
+    // foldersImported counts folders; endpointsImported now folds in saved
+    // requests (1 endpoint + 1 saved request).
+    expect(out.endpointsImported).toBe(2)
+
+    // Resolve the grafted Root → Child and assert the saved request landed
+    // under the *new* Child folder with a fresh id (not the source one).
+    const newRoot = testDb
+      .prepare('SELECT id FROM folders WHERE project_id = ? AND parent_id = ?')
+      .get(SOURCE_PID, destParent) as { id: string }
+    const newChild = testDb
+      .prepare('SELECT id FROM folders WHERE project_id = ? AND parent_id = ?')
+      .get(SOURCE_PID, newRoot.id) as { id: string }
+    const grafted = testDb
+      .prepare('SELECT id, name, method, url FROM saved_requests WHERE folder_id = ?')
+      .get(newChild.id) as { id: string; name: string; method: string; url: string } | undefined
+    expect(grafted).toBeDefined()
+    expect(grafted!.name).toBe('Ping')
+    expect(grafted!.method).toBe('GET')
+    expect(grafted!.url).toBe('https://api.example/ping')
+    expect(grafted!.id).not.toBe(savedInFolder)
+  })
 })

--- a/tests/renderer/folder-runner-page.test.ts
+++ b/tests/renderer/folder-runner-page.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Folder context-menu "Run" must land the user on a page where the runner is
+ * actually visible (regression #39).
+ *
+ * A runner tab `tabBelongsToPage` the **Tests** page. When "Run" is invoked
+ * from the APIs tree, the runner tab becomes active but the visible sidebar
+ * page is still APIs, so the Workbench treats the off-page active tab as absent
+ * and shows the APIs welcome — the runner never appears and the click looks
+ * like a no-op. openFolderRunner() fixes this by switching to the Tests page.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { openFolderRunner } from '../../src/renderer/lib/open-runner-tab'
+import { useTabsStore } from '../../src/renderer/stores/tabs.store'
+import { useUIStore } from '../../src/renderer/stores/ui.store'
+import { tabBelongsToPage } from '../../src/renderer/lib/sidebar-pages'
+
+describe('openFolderRunner — page navigation (#39)', () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeTabId: null })
+    useUIStore.setState({ activeSidebarPage: 'apis' })
+  })
+
+  it('opens a runner tab scoped to the folder and activates it', () => {
+    openFolderRunner('folder-1', 'My Folder')
+    const { tabs, activeTabId } = useTabsStore.getState()
+    expect(tabs).toHaveLength(1)
+    const tab = tabs[0]
+    expect(tab.id).toBe('runner-folder-1')
+    expect(tab.protocol).toBe('runner')
+    expect(tab.folderId).toBe('folder-1')
+    expect(tab.name).toBe('My Folder')
+    expect(activeTabId).toBe('runner-folder-1')
+  })
+
+  it('switches the sidebar page to Tests so the runner is visible', () => {
+    openFolderRunner('folder-1', 'My Folder')
+    expect(useUIStore.getState().activeSidebarPage).toBe('tests')
+
+    // The decisive invariant: the runner tab is visible on the now-active page.
+    // Without the page switch it would belong to Tests while the user is on
+    // APIs — active but hidden (the no-op symptom).
+    const tab = useTabsStore.getState().tabs[0]
+    expect(tabBelongsToPage(tab, 'tests')).toBe(true)
+    expect(tabBelongsToPage(tab, 'apis')).toBe(false)
+  })
+
+  it('falls back to a generic name when none is given', () => {
+    openFolderRunner('folder-2')
+    expect(useTabsStore.getState().tabs[0].name).toBe('Runner')
+  })
+})

--- a/tests/renderer/update-modal-mac.test.tsx
+++ b/tests/renderer/update-modal-mac.test.tsx
@@ -1,0 +1,67 @@
+/// <reference types="react" />
+import * as React from 'react'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+;(globalThis as unknown as { React: typeof React }).React = React
+
+import UpdateModal from '../../src/renderer/components/modals/UpdateModal'
+import { useUpdaterStore } from '../../src/renderer/stores/updater.store'
+import { useUIStore } from '../../src/renderer/stores/ui.store'
+
+const DOWNLOAD_PAGE = 'https://www.testnizer.com/download/'
+
+function setUserAgent(ua: string): void {
+  Object.defineProperty(window.navigator, 'userAgent', { value: ua, configurable: true })
+}
+
+// Radix Dialog touches a few DOM APIs jsdom doesn't implement.
+function stubDom(): void {
+  if (!('ResizeObserver' in globalThis)) {
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  }
+  HTMLElement.prototype.hasPointerCapture = () => false
+  HTMLElement.prototype.scrollIntoView = () => {}
+}
+
+describe('UpdateModal — macOS routes to manual download (#34)', () => {
+  beforeEach(() => {
+    stubDom()
+    useUIStore.setState({ showUpdateModal: true })
+    // An update is available; releaseNotes null to skip the sanitize path.
+    useUpdaterStore.setState({ status: 'available', version: '9.9.9', releaseNotes: null })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useUIStore.setState({ showUpdateModal: false })
+  })
+
+  it('offers a manual-download link as the primary action on macOS', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36')
+    render(<UpdateModal />)
+
+    const links = screen
+      .getAllByRole('link')
+      .filter((a) => a.getAttribute('href') === DOWNLOAD_PAGE)
+    expect(links.length).toBeGreaterThan(0)
+    // The explanatory note is shown so the user understands why.
+    expect(screen.getByText(/Automatic install is not available/i)).toBeTruthy()
+  })
+
+  it('keeps the in-app Download button on non-macOS', () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36')
+    render(<UpdateModal />)
+
+    // No download-page link in the available state off macOS …
+    const manualLinks = screen
+      .queryAllByRole('link')
+      .filter((a) => a.getAttribute('href') === DOWNLOAD_PAGE)
+    expect(manualLinks).toHaveLength(0)
+    // … the auto-update button drives the flow instead.
+    expect(screen.getByRole('button', { name: /^Download$/i })).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Fixes the four issues re-opened/filed after v1.4.8 shipped.

## Issues
- apinizer/testnizer-releases#32 — Native folder export dropped saved requests (only the `endpoints` table was collected; a collection of saved requests round-tripped empty). FolderExport now carries `savedRequests`; export collects them, import remaps id + folder_id. **Logic test added.**
- apinizer/testnizer-releases#39 — Folder context-menu **Run** was a no-op. The runner tab lives on the **Tests** page; opened from APIs it became active but stayed hidden. New `openFolderRunner()` opens the runner **and** switches to the Tests page. **Logic test added.**
- apinizer/testnizer-releases#33 — Windows install created no shortcut. `installer.nsh` now explicitly `CreateShortCut` (Start Menu + Desktop) after the cleanup, guaranteeing a launch point regardless of electron-builder's conditional logic. ⚠️ **Needs verification on a real Windows install** (can't repro from macOS).
- apinizer/testnizer-releases#34 — In-app macOS update fails. Root cause is the **ad-hoc/unsigned** build: electron-updater can't self-install it. On macOS the update modal now routes "Update available" straight to the **manual download** with an explanatory note instead of a Download & Install button that always fails. ⚠️ **A true auto-update fix needs Apple signing + notarization.**

## Tests
- `tests/main/project-export-import-roundtrip.test.ts` — saved-request folder round-trip (#32)
- `tests/renderer/folder-runner-page.test.ts` — `openFolderRunner` page switch + visibility (#39)
- `tests/renderer/update-modal-mac.test.tsx` — macOS manual-download routing (#34)
- Full suite: **1459 pass**, typecheck + lint clean.

## Notes
- #33 and #34 are environment/signing-bound; the code change is the best achievable without a Windows box / Apple Developer signing, and each is flagged above for real-environment verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
