### PR TITLE
fix: follow-ups for re-reported #32 (Home refresh) + #39 (runner view)

### DIFF
--- a/src/renderer/components/modals/ImportModal.tsx
+++ b/src/renderer/components/modals/ImportModal.tsx
@@ -521,10 +521,13 @@ export default function ImportModal() {
             workspaceId: wsId,
             content: pendingFileContent || '',
           })) as typeof importResult
-          // Surface the imported project: switch to it so the user sees the
-          // content instead of an empty placeholder in the current project.
+          // Surface the imported project: refresh the workspace project list so
+          // it shows on the Home grid without an app restart (#32 follow-up —
+          // setActiveProject alone left `projects` stale, so the new project
+          // only appeared after a reload), then switch to it.
           const newPid = (importResult?.data as { projectId?: string } | undefined)?.projectId
           if (importResult?.success && newPid) {
+            await useWorkspaceStore.getState().fetchProjects(wsId)
             useWorkspaceStore.getState().setActiveProject(newPid)
           }
         } else {

--- a/src/renderer/lib/open-runner-tab.ts
+++ b/src/renderer/lib/open-runner-tab.ts
@@ -41,8 +41,15 @@ export function openOrReuseRunnerTab(
  */
 export function openFolderRunner(folderId: string, folderName?: string): void {
   const tabsApi = useTabsStore.getState()
+  const tabId = 'runner-' + folderId
+  // RunnerTab defaults a fresh tab to the Tests *overview* ('home'), not the
+  // run config — explicit entry points opt into 'config' themselves. Without
+  // this the folder runner opened on the generic Overview instead of a run
+  // scoped to the folder (#39). RunnerTab's view initializer restores 'config'
+  // when this key is set AND the tab carries a folder scope.
+  sessionStorage.setItem(`runner-view-${tabId}`, 'config')
   tabsApi.openTab({
-    id: 'runner-' + folderId,
+    id: tabId,
     name: folderName || 'Runner',
     protocol: 'runner',
     folderId,

--- a/tests/renderer/folder-runner-page.test.ts
+++ b/tests/renderer/folder-runner-page.test.ts
@@ -19,6 +19,7 @@ describe('openFolderRunner — page navigation (#39)', () => {
   beforeEach(() => {
     useTabsStore.setState({ tabs: [], activeTabId: null })
     useUIStore.setState({ activeSidebarPage: 'apis' })
+    sessionStorage.clear()
   })
 
   it('opens a runner tab scoped to the folder and activates it', () => {
@@ -43,6 +44,15 @@ describe('openFolderRunner — page navigation (#39)', () => {
     const tab = useTabsStore.getState().tabs[0]
     expect(tabBelongsToPage(tab, 'tests')).toBe(true)
     expect(tabBelongsToPage(tab, 'apis')).toBe(false)
+  })
+
+  it('seeds the runner view to config so it shows the folder run, not Overview', () => {
+    // Regression #39 follow-up: a fresh runner tab defaults to the Tests
+    // overview; the folder run must land on the run config scoped to the
+    // folder. RunnerTab restores 'config' from this key when the tab has a
+    // folder scope.
+    openFolderRunner('folder-1', 'My Folder')
+    expect(sessionStorage.getItem('runner-view-runner-folder-1')).toBe('config')
   })
 
   it('falls back to a generic name when none is given', () => {


### PR DESCRIPTION
Follow-up fixes for the two issues re-reported after v1.4.9. The original bugs (empty folder import, folder Run no-op) are confirmed fixed by the reporter; these address the **new sub-problems** that surfaced.

## Issues
- apinizer/testnizer-releases#32 — round-trip import now works, but a native **project** import left the Home page stale (`projects` not re-fetched), so the imported project only appeared after an app restart. `ImportModal` now calls `fetchProjects(wsId)` before switching to the new project.
- apinizer/testnizer-releases#39 — folder **Run** now navigates to the Tests page, but opened the generic **Overview** instead of a folder-scoped run. RunnerTab defaults a fresh tab to `'home'`; `openFolderRunner` now seeds the per-tab view key to `'config'` so RunnerTab restores the folder-scoped run config.

## Tests
- `tests/renderer/folder-runner-page.test.ts` — asserts the `runner-view-*` config seed (#39)
- Full suite: **1460 pass**, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
