### PR TITLE
fix(runner): persist script-written env vars + insomnia/bru script aliases (issue #12)

### DIFF
--- a/src/main/ipc/runner.handler.ts
+++ b/src/main/ipc/runner.handler.ts
@@ -10,6 +10,7 @@ import {
 import * as endpointRepo from '../db/endpoint.repo'
 import * as tsiRepo from '../db/test-suite-item.repo'
 import * as historyRepo from '../db/history.repo'
+import * as envRepo from '../db/environment.repo'
 import { getDb } from '../db/database'
 import { isRunnableInProject } from '../lib/ownership'
 import { resolveVariables } from '../lib/variable-resolver'
@@ -85,6 +86,15 @@ interface RunnerExecuteOptions {
    * the report still has assertions, status, timing and size.
    */
   persistResponses?: boolean
+  /**
+   * Postman "Keep variable values" — when true (default) environment / global
+   * variables written by scripts during the run (`pm.environment.set`,
+   * `insomnia.environment.set`, …) are persisted back to the active environment
+   * after the run completes, so a token fetched once in a setup request is
+   * reused (and refreshed in one place) by every later request and by
+   * subsequent runs. Set false to keep the run side-effect-free (issue #12).
+   */
+  keepVariableValues?: boolean
   folderName?: string
   source?: string
   sourceLabel?: string
@@ -155,6 +165,14 @@ interface RunnerReport {
   passedAssertions: number
   failedAssertions: number
   results: EndpointRunResult[]
+  /**
+   * Variables written by scripts during the run and (when keepVariableValues
+   * is on) persisted to the active environment / project globals. The renderer
+   * uses these deltas to refresh its in-memory env store so the next "Send"
+   * and the env editor reflect the new values without a manual reload.
+   */
+  envUpdates?: Record<string, string>
+  globalUpdates?: Record<string, string>
 }
 
 // ─── State ───────────────────────────────────────────────────────
@@ -518,7 +536,10 @@ function sendProgress(progress: RunnerProgress): void {
 
 interface ScriptContext {
   envVars: Record<string, string>
+  /** Active-environment writes (pm.environment.set / collectionVariables.set). */
   envUpdates: Record<string, string>
+  /** Global writes (pm.globals.set) — persisted to project globals, not the env. */
+  globalUpdates: Record<string, string>
   iterationData: Record<string, string>
   iterationIndex: number
   iterationCount: number
@@ -542,6 +563,7 @@ function newScriptContext(
   return {
     envVars: { ...envVars },
     envUpdates: {},
+    globalUpdates: {},
     iterationData,
     iterationIndex,
     iterationCount,
@@ -602,14 +624,20 @@ function runUserScript(
         get: (k: string) => ctx.envVars[k] ?? '',
         set: (k: string, v: unknown) => {
           ctx.envVars[k] = String(v)
-          ctx.envUpdates[k] = String(v)
+          ctx.globalUpdates[k] = String(v)
+        },
+        unset: (k: string) => {
+          delete ctx.envVars[k]
+          ctx.globalUpdates[k] = ''
         },
       },
+      // pm.variables.* are request-local / ephemeral (Postman semantics): they
+      // resolve within this run for convenience but are deliberately NOT routed
+      // into envUpdates, so "Keep variable values" never persists them.
       variables: {
         get: (k: string) => ctx.envVars[k] ?? '',
         set: (k: string, v: unknown) => {
           ctx.envVars[k] = String(v)
-          ctx.envUpdates[k] = String(v)
         },
       },
       collectionVariables: {
@@ -649,8 +677,15 @@ function runUserScript(
   }
 
   try {
-    const fn = new Function('pm', 'console', script)
-    fn(buildPm(), { log, warn: log, error: log })
+    // `insomnia` and `bru` are aliases of the same shim so scripts imported
+    // from Insomnia v5 (`insomnia.environment.set(...)`) and Bruno run
+    // unchanged alongside Postman's `pm.*`. Before this they threw
+    // "insomnia is not defined", the catch below swallowed it, and the env
+    // write never happened — folder runs then sent an empty `{{accessToken}}`
+    // and got 401 (issue #12).
+    const pm = buildPm()
+    const fn = new Function('pm', 'insomnia', 'bru', 'console', script)
+    fn(pm, pm, pm, { log, warn: log, error: log })
   } catch (e) {
     ctx.consoleLogs.push(`Script error: ${(e as Error).message}`)
   }
@@ -1042,6 +1077,14 @@ async function executeCollection(options: RunnerExecuteOptions): Promise<RunnerR
   }
   const envVars = loadEnvironmentVariables(effectiveEnvId, options.workspaceId, options.projectId)
 
+  // Run-level accumulators for every variable a script writes. `envVars` is
+  // mutated in place so updates flow to *later requests within this run*; these
+  // two records additionally capture the net deltas so they can be persisted to
+  // the DB after the run (Postman "Keep variable values") and returned to the
+  // renderer to refresh its in-memory env store (issue #12).
+  const runEnvUpdates: Record<string, string> = {}
+  const runGlobalUpdates: Record<string, string> = {}
+
   let totalAssertions = 0
   let passedAssertions = 0
   let failedAssertions = 0
@@ -1115,10 +1158,7 @@ async function executeCollection(options: RunnerExecuteOptions): Promise<RunnerR
           const scriptCtx = newScriptContext(envVars, iterationData[iter] ?? {}, iter, iterations)
           if (schemaForScripts.preScript) {
             runUserScript(schemaForScripts.preScript, scriptCtx, null)
-            // Push script env updates back into the global env vars map.
-            for (const [k, v] of Object.entries(scriptCtx.envUpdates)) {
-              envVars[k] = v
-            }
+            mergeScriptUpdates(scriptCtx, envVars, runEnvUpdates, runGlobalUpdates)
             if (scriptCtx.skipRequest) {
               const skipResult: EndpointRunResult = {
                 endpointId,
@@ -1151,6 +1191,7 @@ async function executeCollection(options: RunnerExecuteOptions): Promise<RunnerR
           const scriptTestResults: AssertionResult[] = []
           if (schemaForScripts.postScript) {
             scriptCtx.envUpdates = {}
+            scriptCtx.globalUpdates = {}
             runUserScript(schemaForScripts.postScript, scriptCtx, {
               status: response.status,
               statusText: response.statusText,
@@ -1158,9 +1199,7 @@ async function executeCollection(options: RunnerExecuteOptions): Promise<RunnerR
               body: response.body,
               bodySize: response.bodySize,
             })
-            for (const [k, v] of Object.entries(scriptCtx.envUpdates)) {
-              envVars[k] = v
-            }
+            mergeScriptUpdates(scriptCtx, envVars, runEnvUpdates, runGlobalUpdates)
             for (const t of scriptCtx.testResults) {
               scriptTestResults.push({
                 name: t.name,
@@ -1342,6 +1381,14 @@ async function executeCollection(options: RunnerExecuteOptions): Promise<RunnerR
     activeRuns.delete(runId)
   }
 
+  // Persist script-written variables back to the DB (Postman "Keep variable
+  // values", default on). Mirrors the renderer's Send-path
+  // `environment.store.applyScriptUpdates` so a token fetched once survives
+  // across separate folder runs and shows up in the env editor (issue #12).
+  if (options.keepVariableValues !== false) {
+    persistRunVariableUpdates(effectiveEnvId, options.projectId, runEnvUpdates, runGlobalUpdates)
+  }
+
   const completedAt = Date.now()
   const durationMs = completedAt - startedAt
   const avgRespTime =
@@ -1397,6 +1444,95 @@ async function executeCollection(options: RunnerExecuteOptions): Promise<RunnerR
     passedAssertions,
     failedAssertions,
     results,
+    envUpdates: runEnvUpdates,
+    globalUpdates: runGlobalUpdates,
+  }
+}
+
+/**
+ * Merge a single script execution's writes into the run-level state: the live
+ * `envVars` map (so later requests in this run resolve the new values) and the
+ * persisted-delta accumulators. Called after both pre- and post-scripts.
+ */
+function mergeScriptUpdates(
+  ctx: ScriptContext,
+  envVars: Record<string, string>,
+  runEnvUpdates: Record<string, string>,
+  runGlobalUpdates: Record<string, string>,
+): void {
+  for (const [k, v] of Object.entries(ctx.envUpdates)) {
+    envVars[k] = v
+    runEnvUpdates[k] = v
+  }
+  for (const [k, v] of Object.entries(ctx.globalUpdates)) {
+    envVars[k] = v
+    runGlobalUpdates[k] = v
+  }
+}
+
+/**
+ * Write the net variable deltas of a run back to the database: environment
+ * writes go to the project's active environment, global writes to the project's
+ * globals (creating rows that don't exist yet, updating the current `value`
+ * column of those that do). Best-effort — a persistence failure must never fail
+ * the run or lose the report, so everything is wrapped in try/catch.
+ */
+function persistRunVariableUpdates(
+  environmentId: string | undefined,
+  projectId: string,
+  envUpdates: Record<string, string>,
+  globalUpdates: Record<string, string>,
+): void {
+  // ── Active-environment variables ───────────────────────────────
+  const envKeys = Object.keys(envUpdates)
+  if (environmentId && envKeys.length > 0) {
+    try {
+      const byKey = new Map(envRepo.getVariablesByEnvironment(environmentId).map((r) => [r.key, r]))
+      for (const key of envKeys) {
+        const row = byKey.get(key)
+        if (row) {
+          envRepo.updateVariable(row.id, { value: envUpdates[key] })
+        } else {
+          envRepo.createVariable({ environment_id: environmentId, key, value: envUpdates[key] })
+        }
+      }
+    } catch (e) {
+      console.error('[runner] persist env variable updates failed:', (e as Error).message)
+    }
+  }
+
+  // ── Project globals ────────────────────────────────────────────
+  const globalKeys = Object.keys(globalUpdates)
+  if (projectId && globalKeys.length > 0) {
+    try {
+      const byKey = new Map(envRepo.getGlobalVariablesByProject(projectId).map((r) => [r.key, r]))
+      let workspaceId: string | undefined
+      for (const key of globalKeys) {
+        const row = byKey.get(key)
+        if (row) {
+          envRepo.updateGlobalVariable(row.id, { value: globalUpdates[key] })
+        } else {
+          // Creating a row needs the FK workspace_id — derive it once from the
+          // project (the renderer scopes globals per-project, so we match that).
+          if (workspaceId === undefined) {
+            const proj = getDb()
+              .prepare('SELECT workspace_id FROM projects WHERE id = ?')
+              .get(projectId) as { workspace_id: string } | undefined
+            workspaceId = proj?.workspace_id ?? ''
+          }
+          if (workspaceId) {
+            envRepo.createGlobalVariable({
+              workspace_id: workspaceId,
+              project_id: projectId,
+              key,
+              value: globalUpdates[key],
+            })
+          }
+        }
+      }
+    } catch (e) {
+      console.error('[runner] persist global variable updates failed:', (e as Error).message)
+    }
   }
 }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -600,6 +600,9 @@ interface RunnerExecuteOptions {
   /** Persist requestHeaders/requestBody/responseHeaders/responseBody on each
    *  result. Default true; set false to keep memory low for very large runs. */
   persistResponses?: boolean
+  /** Postman "Keep variable values" — persist script-written env/global
+   *  variables back to the active environment after the run. Default true. */
+  keepVariableValues?: boolean
   folderName?: string
   sourceLabel?: string
 }
@@ -649,6 +652,10 @@ interface RunnerReport {
   passedAssertions: number
   failedAssertions: number
   results: EndpointRunResult[]
+  /** Variables written by scripts during the run (and persisted when
+   *  keepVariableValues is on) — renderer refreshes its env store from these. */
+  envUpdates?: Record<string, string>
+  globalUpdates?: Record<string, string>
 }
 
 interface RunnerExportOptions {

--- a/src/renderer/lib/test-runner.ts
+++ b/src/renderer/lib/test-runner.ts
@@ -1087,11 +1087,15 @@ export async function runScript(script: string, pmApi: PmApi): Promise<ScriptRun
   try {
     // `t` is a Testnizer-branded alias for `pm`. Both bind to the same API so
     // imported Postman scripts (which use `pm.*`) keep working unchanged, while
-    // new Testnizer scripts can opt into the shorter `t.*` form. CryptoJS is
+    // new Testnizer scripts can opt into the shorter `t.*` form. `insomnia` and
+    // `bru` are likewise aliases so scripts imported from Insomnia v5
+    // (`insomnia.environment.set(...)`) and Bruno run unchanged — without them
+    // those scripts threw "insomnia is not defined", the catch swallowed it,
+    // and the env write silently never happened (issue #12). CryptoJS is
     // exposed for HMAC / SHA / AES use cases (AWS sig v4, webhook signing) —
     // mirrors Postman's built-in (Mehmet BUG-05).
-    const fn = new Function('pm', 't', 'console', 'CryptoJS', script)
-    fn(pmApi, pmApi, captureConsole, CryptoJS)
+    const fn = new Function('pm', 't', 'insomnia', 'bru', 'console', 'CryptoJS', script)
+    fn(pmApi, pmApi, pmApi, pmApi, captureConsole, CryptoJS)
   } catch (e) {
     const msg = (e as Error).message
     if (msg !== '__pm_skip_request_signal__') {

--- a/src/renderer/stores/runner.store.ts
+++ b/src/renderer/stores/runner.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { HttpMethod } from '../types'
+import { useEnvironmentStore } from './environment.store'
 
 // ─── Types matching main process runner ─────────────────────
 
@@ -58,6 +59,10 @@ export interface RunnerReport {
   passedAssertions: number
   failedAssertions: number
   results: EndpointRunResult[]
+  /** Script-written variables persisted during the run (issue #12). The store
+   *  refreshes the env store from these so the env editor + next Send see them. */
+  envUpdates?: Record<string, string>
+  globalUpdates?: Record<string, string>
 }
 
 type RunnerView = 'config' | 'results'
@@ -186,6 +191,7 @@ export const useRunnerStore = create<RunnerStore>((set, get) => ({
         iterations: state.iterations,
         stopOnError: state.stopOnError,
         persistResponses: state.persistResponses,
+        keepVariableValues: state.keepVariableValues,
       })
 
       acceptProgress = false
@@ -198,6 +204,17 @@ export const useRunnerStore = create<RunnerStore>((set, get) => ({
           currentIndex: report.totalEndpoints,
           totalCount: report.totalEndpoints,
         })
+        // Scripts may have written env/global variables that the main process
+        // already persisted to the DB (Keep variable values). Refresh the env
+        // store so the env editor and the next "Send" see them without a manual
+        // reload (issue #12).
+        const wroteVars =
+          Object.keys(report.envUpdates ?? {}).length > 0 ||
+          Object.keys(report.globalUpdates ?? {}).length > 0
+        if (wroteVars && state.keepVariableValues) {
+          const envStore = useEnvironmentStore.getState()
+          await Promise.all([envStore.fetchEnvironments(), envStore.fetchGlobalVariables()])
+        }
       }
     } catch {
       // Error handled via results — but ensure we stop accepting late progress

--- a/tests/main/handlers/runner-execute.test.ts
+++ b/tests/main/handlers/runner-execute.test.ts
@@ -525,3 +525,144 @@ describe('executeCollection — assertions', () => {
     expect(res.data?.failedAssertions).toBe(0)
   })
 })
+
+// ─── g. Script-written variables persist (issue #12) ─────────────
+//
+// "Fetch a token once, reuse it across the suite, refresh it in one place."
+// Two regressions broke this: (1) the script sandbox only exposed `pm`, so
+// Insomnia-imported `insomnia.environment.set(...)` threw "insomnia is not
+// defined" and the write silently never happened; (2) even when the write
+// landed, the runner never persisted it back to the DB, so a second folder run
+// saw an empty `{{accessToken}}` and got 401.
+
+/** Read a variable row from the project's active environment. */
+function readActiveEnvVar(key: string): { value: string } | undefined {
+  const env = testDb
+    .prepare('SELECT id FROM environments WHERE project_id = ? AND is_active = 1 LIMIT 1')
+    .get(projectId) as { id: string } | undefined
+  if (!env) return undefined
+  return testDb
+    .prepare('SELECT value FROM environment_variables WHERE environment_id = ? AND key = ?')
+    .get(env.id, key) as { value: string } | undefined
+}
+
+describe('executeCollection — script variable persistence (issue #12)', () => {
+  it('reuses a pm.environment.set token in a later request within the same run', async () => {
+    seedActiveBaseEnv()
+    const loginId = seedEndpoint({
+      name: 'Login',
+      method: 'POST',
+      url: '{{base}}/token',
+      // Derive the token from the response so pm.response.json() is exercised
+      // too — echo server returns { ok, path, echo }; path of /token → 'token'.
+      postScript: `pm.environment.set('accessToken', 'TOK-' + pm.response.json().path.slice(1))`,
+    })
+    const dataId = seedEndpoint({
+      name: 'Data',
+      url: '{{base}}/data?t={{accessToken}}',
+    })
+
+    const res = await run({ endpointIds: [loginId, dataId] })
+
+    expect(res.success).toBe(true)
+    expect(received.map((r) => r.url)).toEqual(['/token', '/data?t=TOK-token'])
+  })
+
+  it('honours insomnia.environment.set (Insomnia v5 imports) — was silently dropped', async () => {
+    seedActiveBaseEnv()
+    const loginId = seedEndpoint({
+      name: 'Login',
+      url: '{{base}}/login',
+      postScript: `insomnia.environment.set('accessToken', 'INSO-TOKEN')`,
+    })
+    const dataId = seedEndpoint({
+      name: 'Data',
+      url: '{{base}}/data?t={{accessToken}}',
+    })
+
+    const res = await run({ endpointIds: [loginId, dataId] })
+
+    expect(res.success).toBe(true)
+    // Before the fix this was '/data?t=' (empty) → 401 in the real report.
+    expect(received[1].url).toBe('/data?t=INSO-TOKEN')
+  })
+
+  it('persists a script-written env var to the DB after the run (Keep variable values, default on)', async () => {
+    seedActiveBaseEnv()
+    const loginId = seedEndpoint({
+      name: 'Login',
+      url: '{{base}}/login',
+      postScript: `pm.environment.set('accessToken', 'PERSISTED')`,
+    })
+
+    const res = await run({ endpointIds: [loginId] })
+
+    expect(res.success).toBe(true)
+    // The new var was created in the active environment...
+    expect(readActiveEnvVar('accessToken')?.value).toBe('PERSISTED')
+    // ...and the delta is surfaced on the report for the renderer to refresh.
+    const data = res.data as unknown as { envUpdates?: Record<string, string> }
+    expect(data.envUpdates?.accessToken).toBe('PERSISTED')
+  })
+
+  it('updates an existing env var value rather than duplicating it', async () => {
+    // Pre-seed accessToken with an empty current value (the common imported-
+    // collection shape) — the run should overwrite it, not add a second row.
+    seedActiveEnv({ base: `http://127.0.0.1:${port}`, accessToken: '' })
+    const loginId = seedEndpoint({
+      name: 'Login',
+      url: '{{base}}/login',
+      postScript: `pm.environment.set('accessToken', 'REFRESHED')`,
+    })
+
+    await run({ endpointIds: [loginId] })
+
+    const env = testDb
+      .prepare('SELECT id FROM environments WHERE project_id = ? AND is_active = 1 LIMIT 1')
+      .get(projectId) as { id: string }
+    const rows = testDb
+      .prepare('SELECT value FROM environment_variables WHERE environment_id = ? AND key = ?')
+      .all(env.id, 'accessToken') as Array<{ value: string }>
+    expect(rows.length).toBe(1)
+    expect(rows[0].value).toBe('REFRESHED')
+  })
+
+  it('does NOT persist when keepVariableValues is false (side-effect-free run)', async () => {
+    seedActiveBaseEnv()
+    const loginId = seedEndpoint({
+      name: 'Login',
+      url: '{{base}}/login',
+      postScript: `pm.environment.set('ephemeral', 'X')`,
+    })
+
+    const res = await run({ endpointIds: [loginId], keepVariableValues: false })
+
+    expect(res.success).toBe(true)
+    // Variable resolved within the run but was never written to the DB.
+    expect(readActiveEnvVar('ephemeral')).toBeUndefined()
+  })
+
+  it('persists pm.globals.set writes to the project globals', async () => {
+    seedActiveBaseEnv()
+    const loginId = seedEndpoint({
+      name: 'Login',
+      url: '{{base}}/login',
+      postScript: `pm.globals.set('gKey', 'gVal')`,
+    })
+
+    const res = await run({ endpointIds: [loginId] })
+
+    expect(res.success).toBe(true)
+    const g = testDb
+      .prepare('SELECT value FROM global_variables WHERE project_id = ? AND key = ?')
+      .get(projectId, 'gKey') as { value: string } | undefined
+    expect(g?.value).toBe('gVal')
+    // globals land in globalUpdates, NOT envUpdates.
+    const data = res.data as unknown as {
+      envUpdates?: Record<string, string>
+      globalUpdates?: Record<string, string>
+    }
+    expect(data.globalUpdates?.gKey).toBe('gVal')
+    expect(data.envUpdates?.gKey).toBeUndefined()
+  })
+})

--- a/tests/renderer/test-runner-pm-api.test.ts
+++ b/tests/renderer/test-runner-pm-api.test.ts
@@ -87,6 +87,45 @@ describe('pm.environment', () => {
   })
 })
 
+// ─── Script object aliases: insomnia / bru / t (issue #12) ───────
+//
+// Insomnia v5 and Bruno exports call `insomnia.*` / `bru.*`, and Testnizer
+// scripts may use the short `t.*`. All bind to the same pm shim — before the
+// fix `insomnia.environment.set(...)` threw "insomnia is not defined", runScript
+// swallowed it, and the env write silently vanished (folder Run → empty token).
+
+describe('script object aliases', () => {
+  it('insomnia.environment.set is captured exactly like pm.environment.set', async () => {
+    const pm = makePm(makeResponse())
+    const out = await runScript(`insomnia.environment.set('accessToken', 'INSO')`, pm)
+    expect(out.envUpdates).toEqual({ accessToken: 'INSO' })
+  })
+
+  it('bru.environment.set is captured (Bruno imports)', async () => {
+    const pm = makePm(makeResponse())
+    const out = await runScript(`bru.environment.set('accessToken', 'BRU')`, pm)
+    expect(out.envUpdates).toEqual({ accessToken: 'BRU' })
+  })
+
+  it('t.* is the Testnizer-branded alias of pm.*', async () => {
+    const pm = makePm(makeResponse())
+    const out = await runScript(`t.environment.set('accessToken', 'T')`, pm)
+    expect(out.envUpdates).toEqual({ accessToken: 'T' })
+  })
+
+  it('insomnia and pm share one backing store within a script', async () => {
+    const pm = makePm(makeResponse())
+    const script = `
+      insomnia.environment.set('token', 'shared')
+      pm.test('cross-alias read', () => {
+        pm.expect(pm.environment.get('token')).to.equal('shared')
+      })`
+    const out = await runScript(script, pm)
+    expect(out.results[0].passed).toBe(true)
+    expect(out.envUpdates).toEqual({ token: 'shared' })
+  })
+})
+
 // ─── pm.globals ──────────────────────────────────────────────────
 
 describe('pm.globals', () => {


### PR DESCRIPTION
Fixes the "fetch a token once, reuse it across the suite, refresh it in one place" flow for `issue #12` — script-set environment variables (e.g. `accessToken`) were not persisting, so folder Runs sent an empty `{{accessToken}}` and got **401 Empty Key!** (works in Insomnia v5 + Postman).

## Root causes
1. **`insomnia` / `bru` globals were missing from the script sandbox.** Both the renderer Send path (`test-runner.ts`) and the main Runner (`runner.handler.ts`) only exposed `pm`. An Insomnia v5 import calls `insomnia.environment.set(...)`, which threw `insomnia is not defined`; the surrounding `catch` swallowed it and the env write silently never happened.
2. **The Runner never persisted script-written vars back to the DB.** It mutated env vars in-memory for the current run, but a *separate* folder Run reloaded from the DB and saw the old/empty value. The `keepVariableValues` toggle (Postman "Keep variable values") existed in the UI but was never passed to the backend or honored — a dead switch.

## Changes
- Expose `insomnia` and `bru` as aliases of the `pm` shim in **both** sandboxes (alongside the existing `t`). Insomnia / Bruno / Postman scripts now all run unchanged.
- Runner now honors `keepVariableValues` (default on): script-written **environment** vars persist to the project's active environment, **globals** to the project globals, after the run. Deltas are returned on the report so the renderer refreshes its env store (env editor + next Send see them immediately).
- Properly scope script writes: `pm.globals.*` → globals bucket, `pm.environment`/`collectionVariables` → env bucket, `pm.variables.*` stay request-local/ephemeral (never persisted), matching Postman.

## Tests (fail-before / pass-after) — completion bar per the new "issue done requires tests" rule
- `tests/main/handlers/runner-execute.test.ts` (+6): in-run token reuse across requests, `insomnia.environment.set` honored, DB persistence after run, update-existing-not-duplicate, `keepVariableValues:false` is side-effect-free, `pm.globals.set` → project globals.
- `tests/renderer/test-runner-pm-api.test.ts` (+4): `insomnia` / `bru` / `t` aliases captured in `envUpdates`, shared backing store across aliases.
- Full `npm run test:unit` green (1706 passed, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
