### PR TITLE
UX polish + reliability: fix issues #19–#25 (roll up #15–#18)

### DIFF
--- a/docs/release-notes/v1.4.31.md
+++ b/docs/release-notes/v1.4.31.md
@@ -1,0 +1,56 @@
+## v1.4.31
+
+**A UX-polish and reliability release — your unsaved edits stay put, the tab
+strip stops double-selecting, binary responses are finally viewable, and the
+request/response panes line up.** Closes eleven reported issues.
+
+### Request editing & tabs
+
+- **Unsaved edits are no longer lost (#23):** Query Params, Authorization and
+  Body values typed without clicking Save survived only until you clicked
+  another API and came back. The editor now keeps each tab's working copy, so
+  navigating away and back preserves whatever you were typing — matching
+  Postman / Insomnia.
+- **No more two tabs looking selected (#24):** after a few clicks the tab strip
+  could show two tabs both highlighted as active. The preview-tab reuse logic
+  decoupled a tab's id from the endpoint it showed and a later open minted a
+  duplicate; both are fixed, so exactly one tab is ever active.
+
+### Request & response layout
+
+- **Flush request tables (#21):** the Params and Headers tables dropped their
+  rounded "card" border and side padding so they sit flush against the pane,
+  visually pairing with the borderless response Body / Headers.
+- **Bulk Edit placement (#22):** the Bulk Edit toggle moved out of its own
+  spacer row — which left an empty gap under "Query Params" — into the table's
+  Description header.
+- **Response Headers count badge (#19):** the header count is now a green
+  rounded pill matching the request Headers badge instead of plain grey text.
+
+### Response viewer
+
+- **Binary & document responses (#25):** images, PDFs, audio/video and other
+  binary bodies were mangled by text decoding and showed as garbage. The engine
+  now preserves the raw bytes; the response pane previews images inline, plays
+  PDF / audio / video in a frame, and always offers a Download.
+- **Resizable Headers columns (#20):** the response Headers KEY / VALUE split is
+  now draggable, and the width is remembered across tab switches.
+
+### Runner & import (rolled up)
+
+- **Runner pass/fail follows your assertions (#16):** a request with passing
+  assertions (e.g. an idempotent DELETE asserting `oneOf([200, 400])`) is no
+  longer force-failed just because the HTTP status was ≥ 400.
+- **Imports stop duplicating query params (#17):** a key present in both the URL
+  and the Params table no longer ships twice (`?type=snmp&type=snmp`) — common
+  with Insomnia imports — while legitimately repeated keys are preserved.
+- **Resizable side panels (#15):** the left APIs tree and right Variables pane
+  can be dragged wider / narrower, with the widths persisted.
+- **After-response script body (#18):** added a regression guard confirming
+  `pm.response.json()` / `.body` and `insomnia.response.*` are populated for
+  after-response scripts on the Run path.
+
+**Tests:** new regression coverage for unsaved-edit persistence and duplicate
+tab ids (`tab-edits-persistence`), the Bulk Edit toggle placement
+(`key-value-bulk-toggle`), binary response decoding (`http-engine-binary-body`),
+and the resizable Headers column (`ui-panel-width`).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testnizer",
   "productName": "Testnizer",
-  "version": "1.4.30",
+  "version": "1.4.31",
   "description": "Testnizer — Cross-platform desktop API testing application",
   "main": "./out/main/index.js",
   "homepage": "https://www.testnizer.com",

--- a/src/main/protocols/http.engine.ts
+++ b/src/main/protocols/http.engine.ts
@@ -111,6 +111,8 @@ interface ApiResponse {
   statusText?: string
   headers?: Record<string, string>
   body?: string
+  /** 'base64' when `body` is a base64-encoded binary payload (issue #25). */
+  bodyEncoding?: 'base64'
   bodySize?: number
   timing: ResponseTiming
   error?: string
@@ -128,6 +130,67 @@ function isEventStreamContentType(contentType: string | undefined): boolean {
   if (!contentType) return false
   const mime = contentType.split(';')[0]?.trim().toLowerCase()
   return mime === 'text/event-stream'
+}
+
+/**
+ * Decide whether a response body should be treated as opaque binary (kept as
+ * base64 for the renderer to preview/download) rather than decoded to UTF-8
+ * text. Text families — text/*, JSON, XML, HTML, JS, form-urlencoded, CSV,
+ * YAML, SSE — stay text; images, audio, video, fonts, PDFs and other
+ * application/* payloads are binary (issue #25).
+ */
+function isBinaryContentType(contentType: string | undefined): boolean {
+  if (!contentType) return false
+  const mime = contentType.split(';')[0]?.trim().toLowerCase()
+  if (!mime) return false
+  if (mime.startsWith('text/')) return false
+  if (
+    mime.includes('json') ||
+    mime.includes('xml') ||
+    mime.includes('html') ||
+    mime.includes('javascript') ||
+    mime.includes('ecmascript') ||
+    mime.includes('x-www-form-urlencoded') ||
+    mime.includes('csv') ||
+    mime.includes('yaml') ||
+    mime.includes('graphql') ||
+    mime === 'text/event-stream'
+  ) {
+    return false
+  }
+  return (
+    mime.startsWith('image/') ||
+    mime.startsWith('audio/') ||
+    mime.startsWith('video/') ||
+    mime.startsWith('font/') ||
+    mime.startsWith('application/')
+  )
+}
+
+/**
+ * Normalise an axios response body into the string we hand the renderer.
+ * The engine fetches with `responseType: 'arraybuffer'` so binary payloads
+ * survive intact; this converts the raw bytes back to UTF-8 text for text
+ * content types and to base64 for binary ones. Tolerant of a plain string
+ * (test mocks / the curl sidecar) which is passed through unchanged.
+ */
+function decodeResponseBody(
+  data: unknown,
+  contentType: string | undefined,
+): { body: string; isBase64: boolean; size: number } {
+  if (data == null) return { body: '', isBase64: false, size: 0 }
+  if (typeof data === 'string') {
+    return { body: data, isBase64: false, size: Buffer.byteLength(data, 'utf-8') }
+  }
+  const buf = Buffer.isBuffer(data)
+    ? data
+    : data instanceof ArrayBuffer
+      ? Buffer.from(new Uint8Array(data))
+      : Buffer.from(data as Uint8Array)
+  if (isBinaryContentType(contentType)) {
+    return { body: buf.toString('base64'), isBase64: true, size: buf.length }
+  }
+  return { body: buf.toString('utf-8'), isBase64: false, size: buf.length }
 }
 
 /**
@@ -1021,8 +1084,12 @@ export async function executeHttpRequest(options: HttpRequestOptions): Promise<A
       // disables following so the raw 3xx is returned (issues #25, #26).
       maxRedirects: options.followRedirects === false ? 0 : (options.maxRedirects ?? 5),
       validateStatus: () => true, // Accept all status codes
-      responseType: 'text',
-      transformResponse: [(d: string) => d], // Prevent auto JSON parse
+      // Fetch raw bytes so binary payloads (images / PDFs / octet-stream)
+      // survive instead of being mangled by UTF-8 text decoding (issue #25).
+      // `decodeResponseBody` turns the buffer back into text for text content
+      // types and base64 for binary ones. arraybuffer also bypasses axios's
+      // automatic JSON parse, so no transformResponse override is needed.
+      responseType: 'arraybuffer',
       signal: options.signal,
       // Allow streaming arbitrary-size multipart uploads.
       maxContentLength: Infinity,
@@ -1194,16 +1261,20 @@ export async function executeHttpRequest(options: HttpRequestOptions): Promise<A
       // Cookie extraction failed — not critical
     }
 
-    // Body size
-    const bodyStr = response.data ?? ''
-    const bodySize = Buffer.byteLength(bodyStr, 'utf-8')
+    // Decode the raw response bytes: UTF-8 text for text content types, base64
+    // for binary ones (issue #25). `bodyStr` is base64 when `bodyIsBinary`.
+    const respContentType = responseHeaders['content-type'] ?? responseHeaders['Content-Type']
+    const {
+      body: bodyStr,
+      isBase64: bodyIsBinary,
+      size: bodySize,
+    } = decodeResponseBody(response.data, respContentType)
 
     // Parse Server-Sent Events bodies into a structured event list so the
     // renderer can show a Postman-style "Events" tab. Real-time streaming is
     // handled by `sse.engine.ts`; this is post-processing of the buffered
     // body for one-shot requests that happen to return text/event-stream.
     let sseEvents: SseEventPayload[] | undefined
-    const respContentType = responseHeaders['content-type'] ?? responseHeaders['Content-Type']
     if (isEventStreamContentType(respContentType) && bodyStr) {
       const parsed = parseSseBody(bodyStr)
       if (parsed.length > 0) {
@@ -1255,6 +1326,7 @@ export async function executeHttpRequest(options: HttpRequestOptions): Promise<A
       headers: responseHeaders,
       body: bodyStr,
       bodySize,
+      bodyEncoding: bodyIsBinary ? 'base64' : undefined,
       timing: {
         total: timings.total ?? 0,
         dns: timings.dns,
@@ -1286,16 +1358,23 @@ export async function executeHttpRequest(options: HttpRequestOptions): Promise<A
       const status = axiosErr.response.status
       const hint = hintForHttpStatus(status) ?? axiosErr.response.statusText
       const errorLine = hint ? `HTTP ${status} ${hint}` : `HTTP ${status}`
+      // Decode the error body the same way as the success path — with
+      // responseType:'arraybuffer' the data is a Buffer, so the old
+      // `JSON.stringify` fallback would have produced `{"0":..}` garbage
+      // (and binary error bodies are kept as base64 for preview).
+      const errCt = responseHeaders['content-type'] ?? responseHeaders['Content-Type']
+      const { body: errBody, isBase64: errIsBinary } = decodeResponseBody(
+        axiosErr.response.data,
+        errCt,
+      )
       return {
         requestId,
         protocol: 'http',
         status,
         statusText: axiosErr.response.statusText,
         headers: responseHeaders,
-        body:
-          typeof axiosErr.response.data === 'string'
-            ? axiosErr.response.data
-            : JSON.stringify(axiosErr.response.data),
+        body: errBody,
+        bodyEncoding: errIsBinary ? 'base64' : undefined,
         timing: { total: Math.round(endTime - startTime) },
         error: errorLine,
       }

--- a/src/renderer/components/request/HeadersTab.tsx
+++ b/src/renderer/components/request/HeadersTab.tsx
@@ -20,6 +20,7 @@ export default function HeadersTab() {
         addLabel="+ Add Header"
         enableAutocomplete
         keyAutocompleteEntries={STANDARD_HTTP_HEADERS}
+        flush
       />
     </div>
   )

--- a/src/renderer/components/request/ParamsTab.tsx
+++ b/src/renderer/components/request/ParamsTab.tsx
@@ -10,7 +10,7 @@ export default function ParamsTab() {
 
   return (
     <div>
-      <div className="mb-2 font-medium" style={{ color: 'var(--text)' }}>
+      <div className="mb-2 px-2.5 font-medium" style={{ color: 'var(--text)' }}>
         Query Params
       </div>
       <KeyValueTable
@@ -20,6 +20,7 @@ export default function ParamsTab() {
         onAdd={addParam}
         onReplaceAll={setParams}
         addLabel="+ Add Parameter"
+        flush
       />
     </div>
   )

--- a/src/renderer/components/request/RequestEditor.tsx
+++ b/src/renderer/components/request/RequestEditor.tsx
@@ -135,12 +135,36 @@ export default function RequestEditor() {
           {activeTab === 'scripts' && <ScriptsTab />}
         </div>
       ) : (
-        <div className="flex-1 overflow-y-auto p-2.5">
-          {activeTab === 'params' && <ParamsTab />}
-          {activeTab === 'headers' && <HeadersTab />}
-          {activeTab === 'auth' && <AuthTab />}
-          {activeTab === 'tests' && <TestsTab />}
-          {activeTab === 'settings' && <SettingsTab />}
+        <div className="flex-1 overflow-y-auto">
+          {/* Params / Headers drop the horizontal padding so their tables sit
+              flush against the pane edges, pairing with the borderless
+              response Body / Headers (issue #21). Auth / Tests / Settings keep
+              the inset content padding. */}
+          {activeTab === 'params' && (
+            <div className="py-2.5">
+              <ParamsTab />
+            </div>
+          )}
+          {activeTab === 'headers' && (
+            <div className="py-2.5">
+              <HeadersTab />
+            </div>
+          )}
+          {activeTab === 'auth' && (
+            <div className="p-2.5">
+              <AuthTab />
+            </div>
+          )}
+          {activeTab === 'tests' && (
+            <div className="p-2.5">
+              <TestsTab />
+            </div>
+          )}
+          {activeTab === 'settings' && (
+            <div className="p-2.5">
+              <SettingsTab />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/components/response/HeadersTab.tsx
+++ b/src/renderer/components/response/HeadersTab.tsx
@@ -1,12 +1,50 @@
+import { useRef, useCallback } from 'react'
 import { useResponseStore } from '../../stores/response.store'
+import { useUIStore } from '../../stores/ui.store'
 
 /**
- * Postman-style response headers tab — clean 2-column list.
+ * Postman-style response headers tab — clean 2-column list with a draggable
+ * divider so the KEY / VALUE split can be resized (issue #20). The width is a
+ * percentage persisted in the UI store, so it survives the pane remount that
+ * happens on every tab switch.
  */
 export default function HeadersTab() {
   const response = useResponseStore((s) => s.response)
+  const keyWidth = useUIStore((s) => s.responseHeaderKeyWidth)
+  const setKeyWidth = useUIStore((s) => s.setResponseHeaderKeyWidth)
+  const commitKeyWidth = useUIStore((s) => s.commitResponseHeaderKeyWidth)
+  const tableRef = useRef<HTMLTableElement>(null)
+
   const headers = response?.headers || {}
   const keys = Object.keys(headers).sort((a, b) => a.localeCompare(b))
+
+  // Drag the KEY/VALUE divider. The width is derived from the cursor's x
+  // position relative to the table, as a percentage, so it stays correct as
+  // the response pane itself is resized.
+  const startResize = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      const table = tableRef.current
+      if (!table) return
+      const onMove = (ev: MouseEvent) => {
+        const rect = table.getBoundingClientRect()
+        if (rect.width <= 0) return
+        setKeyWidth(((ev.clientX - rect.left) / rect.width) * 100)
+      }
+      const onUp = () => {
+        window.removeEventListener('mousemove', onMove)
+        window.removeEventListener('mouseup', onUp)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+        commitKeyWidth()
+      }
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+      window.addEventListener('mousemove', onMove)
+      window.addEventListener('mouseup', onUp)
+    },
+    [setKeyWidth, commitKeyWidth],
+  )
 
   if (keys.length === 0) {
     return (
@@ -18,20 +56,41 @@ export default function HeadersTab() {
 
   return (
     <div className="h-full overflow-auto">
-      <table className="w-full border-collapse">
+      <table ref={tableRef} className="w-full border-collapse" style={{ tableLayout: 'fixed' }}>
         <thead>
           <tr style={{ background: 'var(--surface)' }}>
             <th
-              className="text-left font-medium"
+              className="relative text-left font-medium"
               style={{
                 padding: '8px 12px',
                 color: 'var(--muted)',
                 borderBottom: '1px solid var(--border)',
-                width: '35%',
+                width: `${keyWidth}%`,
                 fontSize: 13,
               }}
             >
               KEY
+              {/* Drag handle straddling the KEY/VALUE border. */}
+              <span
+                role="separator"
+                aria-orientation="vertical"
+                data-testid="res-header-col-resize"
+                onMouseDown={startResize}
+                className="absolute top-0 z-10"
+                style={{
+                  right: -3,
+                  height: '100%',
+                  width: 6,
+                  cursor: 'col-resize',
+                }}
+                onMouseEnter={(e) => {
+                  ;(e.currentTarget as HTMLElement).style.background = 'var(--accent)'
+                  ;(e.currentTarget as HTMLElement).style.opacity = '0.4'
+                }}
+                onMouseLeave={(e) => {
+                  ;(e.currentTarget as HTMLElement).style.background = 'transparent'
+                }}
+              />
             </th>
             <th
               className="text-left font-medium"
@@ -50,7 +109,7 @@ export default function HeadersTab() {
           {keys.map((k) => (
             <tr key={k} style={{ borderBottom: '1px solid var(--border-split)' }}>
               <td
-                className="font-mono align-top"
+                className="align-top font-mono"
                 style={{
                   padding: '7px 12px',
                   color: 'var(--json-key)',
@@ -60,7 +119,7 @@ export default function HeadersTab() {
                 {k}
               </td>
               <td
-                className="font-mono align-top"
+                className="align-top font-mono"
                 style={{
                   padding: '7px 12px',
                   color: 'var(--text)',

--- a/src/renderer/components/response/ResponseBody.tsx
+++ b/src/renderer/components/response/ResponseBody.tsx
@@ -2,7 +2,17 @@ import { useState, useMemo, useRef, useEffect } from 'react'
 import { useResponseStore } from '../../stores/response.store'
 import { useTranslation } from '../../lib/i18n'
 import MonacoWrapper from '../shared/MonacoWrapper'
-import { ChevronDown, Play, Image as ImageIcon, WrapText, Filter, Copy, Check } from 'lucide-react'
+import {
+  ChevronDown,
+  Play,
+  Image as ImageIcon,
+  WrapText,
+  Filter,
+  Copy,
+  Check,
+  Download,
+  File as FileIcon,
+} from 'lucide-react'
 
 type ViewMode = 'Pretty' | 'Raw' | 'Preview'
 type FormatMode = 'JSON' | 'XML' | 'HTML' | 'Text'
@@ -136,6 +146,24 @@ export default function ResponseBody() {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
+  }
+
+  // Binary / document bodies (images, PDFs, octet-stream, …) arrive base64 from
+  // the engine and can't be rendered in the text editor — show a preview /
+  // download panel instead (issue #25). Placed after all hooks so the early
+  // return doesn't violate the rules-of-hooks.
+  const binaryContentType = (
+    response?.headers?.['content-type'] ||
+    response?.headers?.['Content-Type'] ||
+    ''
+  )
+    .split(';')[0]
+    .trim()
+    .toLowerCase()
+  if (response?.bodyEncoding === 'base64' && body) {
+    return (
+      <BinaryResponseView base64={body} contentType={binaryContentType} size={response.bodySize} />
+    )
   }
 
   return (
@@ -365,6 +393,150 @@ export default function ResponseBody() {
             sandbox="allow-same-origin"
             title="Response Preview"
           />
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Decode a base64 string into a Blob of the given MIME type (null on failure). */
+function base64ToBlob(b64: string, contentType: string): Blob | null {
+  try {
+    const bin = atob(b64)
+    const bytes = new Uint8Array(bin.length)
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+    return new Blob([bytes], { type: contentType || 'application/octet-stream' })
+  } catch {
+    return null
+  }
+}
+
+/** Best-effort file extension for a content type, for the download filename. */
+function extForContentType(ct: string): string {
+  const map: Record<string, string> = {
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+    'image/svg+xml': 'svg',
+    'image/bmp': 'bmp',
+    'image/x-icon': 'ico',
+    'application/pdf': 'pdf',
+    'application/zip': 'zip',
+    'application/gzip': 'gz',
+    'application/octet-stream': 'bin',
+    'application/msword': 'doc',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+    'application/vnd.ms-excel': 'xls',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+    'audio/mpeg': 'mp3',
+    'audio/wav': 'wav',
+    'audio/ogg': 'ogg',
+    'video/mp4': 'mp4',
+    'video/webm': 'webm',
+  }
+  return map[ct] || 'bin'
+}
+
+function formatBytes(n?: number): string {
+  if (n == null) return ''
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / 1024 / 1024).toFixed(2)} MB`
+}
+
+/**
+ * Preview / download panel for binary response bodies (issue #25). The body
+ * arrives base64-encoded; we rebuild an in-memory Blob and an object URL so
+ * images render inline, PDFs / audio / video play in a frame (CSP allows
+ * `blob:` for frame-src / media-src), and anything else offers a Download.
+ */
+function BinaryResponseView({
+  base64,
+  contentType,
+  size,
+}: {
+  base64: string
+  contentType: string
+  size?: number
+}) {
+  const url = useMemo(() => {
+    const blob = base64ToBlob(base64, contentType)
+    return blob ? URL.createObjectURL(blob) : null
+  }, [base64, contentType])
+
+  // Release the object URL when the body changes or the panel unmounts.
+  useEffect(() => {
+    return () => {
+      if (url) URL.revokeObjectURL(url)
+    }
+  }, [url])
+
+  const isImage = contentType.startsWith('image/')
+  const isPdf = contentType === 'application/pdf'
+  const isAudio = contentType.startsWith('audio/')
+  const isVideo = contentType.startsWith('video/')
+  const filename = `response.${extForContentType(contentType)}`
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Meta + download bar */}
+      <div
+        className="flex shrink-0 items-center gap-3 px-3"
+        style={{ height: 32, borderBottom: '1px solid var(--border)', background: 'var(--white)' }}
+      >
+        <span style={{ color: 'var(--muted)', fontSize: 13 }} data-testid="res-binary-type">
+          {contentType || 'binary'}
+        </span>
+        {size != null && (
+          <span style={{ color: 'var(--hint)', fontSize: 13 }}>{formatBytes(size)}</span>
+        )}
+        <div className="flex-1" />
+        {url && (
+          <a
+            href={url}
+            download={filename}
+            data-testid="res-binary-download"
+            className="flex items-center gap-1 rounded px-2 py-[3px]"
+            style={{
+              color: 'var(--accent-text)',
+              background: 'var(--accent-light)',
+              fontSize: 13,
+              textDecoration: 'none',
+            }}
+          >
+            <Download size={13} /> Download
+          </a>
+        )}
+      </div>
+
+      {/* Preview area */}
+      <div
+        className="flex flex-1 items-center justify-center overflow-auto p-4"
+        style={{ background: 'var(--surface)' }}
+        data-testid="res-binary-preview"
+      >
+        {!url ? (
+          <span style={{ color: 'var(--muted)' }}>Unable to decode binary response.</span>
+        ) : isImage ? (
+          <img
+            src={url}
+            alt="Response"
+            style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+          />
+        ) : isPdf ? (
+          <iframe src={url} title="PDF response" className="h-full w-full border-none" />
+        ) : isAudio ? (
+          <audio controls src={url} />
+        ) : isVideo ? (
+          <video controls src={url} style={{ maxWidth: '100%', maxHeight: '100%' }} />
+        ) : (
+          <div className="flex flex-col items-center gap-2 text-center">
+            <FileIcon size={40} style={{ color: 'var(--muted)' }} />
+            <div style={{ color: 'var(--text)' }}>{contentType || 'Binary file'}</div>
+            <div style={{ color: 'var(--muted)', fontSize: 13 }}>{formatBytes(size)}</div>
+          </div>
         )}
       </div>
     </div>

--- a/src/renderer/components/response/ResponsePane.tsx
+++ b/src/renderer/components/response/ResponsePane.tsx
@@ -310,11 +310,35 @@ export default function ResponsePane() {
     count?: number
     countLabel?: string
     countColor?: string
+    countBg?: string
   }> = [
     { key: 'body', label: 'Body' },
-    ...(eventCount > 0 ? [{ key: 'events' as ResTabKey, label: 'Events', count: eventCount }] : []),
-    { key: 'cookies', label: 'Cookies', count: cookieCount },
-    { key: 'headers', label: 'Headers', count: headerCount },
+    ...(eventCount > 0
+      ? [
+          {
+            key: 'events' as ResTabKey,
+            label: 'Events',
+            count: eventCount,
+            countBg: 'var(--accent-light)',
+            countColor: 'var(--accent-text)',
+          },
+        ]
+      : []),
+    {
+      key: 'cookies',
+      label: 'Cookies',
+      count: cookieCount,
+      countBg: 'var(--accent-light)',
+      countColor: 'var(--accent-text)',
+    },
+    // Green pill, matching the request Headers tab badge (issue #19).
+    {
+      key: 'headers',
+      label: 'Headers',
+      count: headerCount,
+      countBg: 'var(--green-bg)',
+      countColor: 'var(--green)',
+    },
     {
       key: 'testResults',
       label: 'Test Results',
@@ -381,16 +405,29 @@ export default function ResponsePane() {
                 }}
               >
                 {tab.label}
-                {tab.count != null && tab.count > 0 && (
-                  <span
-                    className="ml-1 font-semibold"
-                    style={{
-                      color: tab.countColor || (isActive ? 'var(--accent-text)' : 'var(--hint)'),
-                    }}
-                  >
-                    {tab.countLabel || tab.count}
-                  </span>
-                )}
+                {tab.count != null &&
+                  tab.count > 0 &&
+                  (tab.countBg ? (
+                    // Rounded count pill — same shape as the request-pane badges.
+                    <span
+                      className="ml-1 rounded-full px-[5px] font-semibold"
+                      style={{
+                        background: tab.countBg,
+                        color: tab.countColor || 'var(--accent-text)',
+                      }}
+                    >
+                      {tab.countLabel || tab.count}
+                    </span>
+                  ) : (
+                    <span
+                      className="ml-1 font-semibold"
+                      style={{
+                        color: tab.countColor || (isActive ? 'var(--accent-text)' : 'var(--hint)'),
+                      }}
+                    >
+                      {tab.countLabel || tab.count}
+                    </span>
+                  ))}
               </button>
             )
           })}

--- a/src/renderer/components/shared/KeyValueTable.tsx
+++ b/src/renderer/components/shared/KeyValueTable.tsx
@@ -40,6 +40,13 @@ interface KeyValueTableProps {
    * Edit toggle is hidden.
    */
   onReplaceAll?: (rows: KeyValuePair[]) => void
+  /**
+   * Drop the rounded "card" border around the table so it sits flush against
+   * its container, visually pairing the request Params / Headers tables with
+   * the borderless response Body / Headers panes (issue #21). The form-data /
+   * url-encoded body editors keep the default bordered look.
+   */
+  flush?: boolean
 }
 
 interface AutocompleteState {
@@ -117,6 +124,7 @@ export default function KeyValueTable({
   keyAutocompleteEntries,
   enableFileType = false,
   onReplaceAll,
+  flush = false,
 }: KeyValueTableProps) {
   const keyAutocompleteEnabled = !!keyAutocompleteEntries && keyAutocompleteEntries.length > 0
   const { t } = useTranslation()
@@ -289,46 +297,56 @@ export default function KeyValueTable({
     onReplaceAll(bulkTextToRows(bulkText, bulkSnapshotRef.current))
   }
 
+  // The Bulk Edit ⇄ Key/Value toggle. Previously this sat in its own
+  // `mb-1` row above the table, which pushed an empty gap under the section
+  // header (issue #22). It's now rendered inside the table's Description
+  // header cell (table mode) so the table starts immediately under "Query
+  // Params"; bulk mode keeps a compact top-right toggle so the user can get
+  // back to the table view.
+  const bulkToggle = bulkEditEnabled ? (
+    <button
+      type="button"
+      data-testid="kv-bulk-toggle"
+      onClick={() => {
+        // Commit on the way back to table view so any unsaved edits
+        // in the textarea aren't silently dropped.
+        if (bulkMode) commitBulk()
+        setBulkMode((v) => !v)
+      }}
+      className="cursor-pointer border-none bg-transparent font-normal text-[var(--accent)] hover:underline"
+      style={{ fontSize: 13 }}
+    >
+      {bulkMode ? t('kv.keyValueEdit') : t('kv.bulkEdit')}
+    </button>
+  ) : null
+
   return (
     <div>
-      {bulkEditEnabled && (
-        <div className="mb-1 flex items-center justify-end">
-          <button
-            type="button"
-            data-testid="kv-bulk-toggle"
-            onClick={() => {
-              // Commit on the way back to table view so any unsaved edits
-              // in the textarea aren't silently dropped.
-              if (bulkMode) commitBulk()
-              setBulkMode((v) => !v)
-            }}
-            className="cursor-pointer rounded border border-transparent bg-transparent text-[var(--accent)] hover:underline"
-            style={{ fontSize: 13 }}
-          >
-            {bulkMode ? t('kv.keyValueEdit') : t('kv.bulkEdit')}
-          </button>
-        </div>
-      )}
       {bulkMode ? (
-        <textarea
-          data-testid="kv-bulk-textarea"
-          value={bulkText}
-          onChange={(e) => setBulkText(e.target.value)}
-          onBlur={commitBulk}
-          spellCheck={false}
-          className="w-full rounded-md border border-[var(--border)] p-2 font-mono outline-none focus:border-[var(--accent)]"
-          style={{
-            background: 'var(--white)',
-            color: 'var(--text)',
-            fontSize: 13,
-            minHeight: 180,
-            resize: 'vertical',
-          }}
-          placeholder={'key:value\nkey2:value2\n//disabledKey:disabledValue'}
-        />
+        <>
+          {bulkToggle && <div className="mb-1 flex items-center justify-end">{bulkToggle}</div>}
+          <textarea
+            data-testid="kv-bulk-textarea"
+            value={bulkText}
+            onChange={(e) => setBulkText(e.target.value)}
+            onBlur={commitBulk}
+            spellCheck={false}
+            className="w-full rounded-md border border-[var(--border)] p-2 font-mono outline-none focus:border-[var(--accent)]"
+            style={{
+              background: 'var(--white)',
+              color: 'var(--text)',
+              fontSize: 13,
+              minHeight: 180,
+              resize: 'vertical',
+            }}
+            placeholder={'key:value\nkey2:value2\n//disabledKey:disabledValue'}
+          />
+        </>
       ) : (
         <div
-          className="overflow-visible rounded-md border border-[var(--border)]"
+          className={
+            flush ? 'overflow-visible' : 'overflow-visible rounded-md border border-[var(--border)]'
+          }
           style={{ background: 'var(--white)' }}
         >
           {/* Header */}
@@ -344,7 +362,11 @@ export default function KeyValueTable({
             <div className="px-2.5 py-1">{t('kv.key')}</div>
             {enableFileType && <div className="px-2.5 py-1">{t('kv.type')}</div>}
             <div className="px-2.5 py-1">{t('kv.value')}</div>
-            <div className="px-2.5 py-1">{t('kv.description')}</div>
+            {/* Description header doubles as the Bulk Edit toggle anchor (#22). */}
+            <div className="flex items-center justify-between px-2.5 py-1">
+              <span>{t('kv.description')}</span>
+              {bulkToggle}
+            </div>
             <div />
           </div>
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -12,10 +12,13 @@
       Zustand hydration, so `'unsafe-inline'` is kept for styles only.
       `'unsafe-eval'` is required so user-authored pre-request and
       post-response scripts can execute via `new Function()` (test-runner.ts).
+      `frame-src`/`media-src` allow `blob:` so the response viewer can preview
+      binary bodies (PDF in an iframe, audio/video) from in-memory object URLs
+      built off the base64 body — local only, no network egress (issue #25).
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-eval' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; media-src 'self' blob:; frame-src 'self' blob:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'"
     />
     <title>Testnizer</title>
   </head>

--- a/src/renderer/stores/request.store.ts
+++ b/src/renderer/stores/request.store.ts
@@ -774,6 +774,22 @@ export const useRequestStore = create<RequestStore>((set, get) => ({
 
   loadFromEndpoint: (data) => {
     const state = get()
+    // Don't clobber a tab's unsaved working copy. The tree click / open-tab
+    // paths run `openPreviewTab → switchToTab → loadFromEndpoint`; when the
+    // user re-focuses an already-open endpoint, `switchToTab` has just
+    // restored their in-memory edits, but this `loadFromEndpoint` would then
+    // overwrite them with the pristine DB row — Query Params / Auth / Body
+    // typed without saving vanished on navigate-away-and-back (issue #23).
+    // A dirty tab means there are unsaved edits the working copy owns, so the
+    // DB reload is skipped; a clean tab (fresh open, or post-Save) loads
+    // normally. Gated on the tab being backed by a saved request / endpoint —
+    // matching `markActiveTabDirty`, the only thing that sets the flag.
+    if (state._currentTabId) {
+      const activeTab = useTabsStore.getState().tabs.find((t) => t.id === state._currentTabId)
+      if (activeTab?.isDirty && (activeTab.endpointId || activeTab.savedRequestId)) {
+        return
+      }
+    }
     const newFields = {
       method: data.method,
       url: data.url,

--- a/src/renderer/stores/tabs.store.ts
+++ b/src/renderer/stores/tabs.store.ts
@@ -148,6 +148,19 @@ export const useTabsStore = create<TabsStore>((set, get) => ({
       }
     }
 
+    // Id-level dedup: never mint a second physical tab carrying an id that's
+    // already open. The clean-preview-replace branch below adopts the incoming
+    // payload id (to keep the `tab.id === tab-${resourceId}` invariant), so
+    // without this guard the metadata-less fallback open path (TreeView's
+    // "open with basic info") could land a replaced slot on an id that another
+    // open tab already uses — two tabs sharing one id, both rendering as the
+    // active tab (issue #24 hardening).
+    const dupById = get().tabs.find((t) => t.id === tab.id)
+    if (dupById) {
+      set({ activeTabId: dupById.id })
+      return
+    }
+
     const state = get()
     // Scope the preview slot per workspace kind — APIs preview ≠ Tests
     // preview ≠ Mocks preview. A click in one tree never disturbs another
@@ -164,34 +177,25 @@ export const useTabsStore = create<TabsStore>((set, get) => ({
         const newTab: Tab = { ...tab, isDirty: false, isLoading: false, isPreview: true }
         set((s) => ({ tabs: [...s.tabs, newTab], activeTabId: newTab.id }))
       } else {
-        // Replace the existing (clean) preview tab's content. Identity
-        // fields (endpointId / savedRequestId / mockServerId /
-        // testSuiteItemId / folderId) are mutually exclusive, so we
-        // ALWAYS overwrite each one with the new tab's value — even
-        // when that value is undefined. Without the explicit overrides
-        // a previous suite-item preview would leave `testSuiteItemId`
-        // behind, making the flask icon stick on an APIs-tree preview
-        // that opened in the same slot (and the Save router would still
-        // try to write to test_suite_items).
+        // Replace the existing (clean) preview tab's content. Build the new
+        // tab purely from the incoming payload — crucially ADOPTING its `id`
+        // instead of keeping `existingPreview.id`. The old "keep the slot's
+        // id" behaviour decoupled a physical tab id from the resource it
+        // showed (`tab.id` stopped equalling `tab-${endpointId}`); a later
+        // open of the original resource then minted a NEW tab whose
+        // `tab-${id}` collided with this stale slot, so two tabs shared one id
+        // and BOTH rendered as the active tab (issue #24). Rebuilding from the
+        // payload also drops any stale identity field (endpointId /
+        // savedRequestId / mockServerId / testSuiteItemId / folderId) for free
+        // — those are mutually exclusive, so a fresh object carries only the
+        // new resource's id and keeps the flask icon / Save router correct.
         set((s) => ({
           tabs: s.tabs.map((t) =>
             t.id === existingPreview.id
-              ? {
-                  ...t,
-                  ...tab,
-                  id: existingPreview.id,
-                  endpointId: tab.endpointId,
-                  savedRequestId: tab.savedRequestId,
-                  mockServerId: tab.mockServerId,
-                  testSuiteItemId: tab.testSuiteItemId,
-                  folderId: tab.folderId,
-                  isDirty: false,
-                  isLoading: false,
-                  isPreview: true,
-                }
+              ? { ...tab, isDirty: false, isLoading: false, isPreview: true }
               : t,
           ),
-          activeTabId: existingPreview.id,
+          activeTabId: tab.id,
         }))
       }
     } else {

--- a/src/renderer/stores/ui.store.ts
+++ b/src/renderer/stores/ui.store.ts
@@ -37,6 +37,8 @@ interface UIStore {
   accentColor: string
   leftPanelWidth: number
   rightPanelWidth: number
+  /** Response Headers table KEY-column width, as a percentage (issue #20). */
+  responseHeaderKeyWidth: number
   splitPosition: number
   isLeftPanelCollapsed: boolean
   activeSidebarPage: SidebarPage
@@ -80,6 +82,10 @@ interface UIStore {
   setRightPanelWidth: (width: number) => void
   /** Persist the current left/right panel widths (called once on drag end). */
   commitPanelWidths: () => void
+  /** Live setter while dragging the response Headers KEY column (issue #20). */
+  setResponseHeaderKeyWidth: (pct: number) => void
+  /** Persist the response Headers KEY-column width (called once on drag end). */
+  commitResponseHeaderKeyWidth: () => void
   setSplitPosition: (position: number) => void
   toggleLeftPanel: () => void
   setLeftPanelCollapsed: (collapsed: boolean) => void
@@ -165,6 +171,7 @@ export const useUIStore = create<UIStore>((set, get) => ({
   accentColor: '#2D5FA0',
   leftPanelWidth: 300,
   rightPanelWidth: 300,
+  responseHeaderKeyWidth: 35,
   splitPosition: 50,
   isLeftPanelCollapsed: false,
   activeSidebarPage: 'apis',
@@ -237,9 +244,11 @@ export const useUIStore = create<UIStore>((set, get) => ({
         'ui.accentColor',
         'ui.leftPanelWidth',
         'ui.rightPanelWidth',
+        'ui.responseHeaderKeyWidth',
       ] as const
       const results = await Promise.all(keys.map((k) => api.get!(k)))
-      const [themeRes, localeRes, sizeRes, familyRes, accentRes, leftWRes, rightWRes] = results
+      const [themeRes, localeRes, sizeRes, familyRes, accentRes, leftWRes, rightWRes, hdrKeyWRes] =
+        results
       const patch: Partial<UIStore> = {}
       const themeVal = themeRes?.data as Theme | undefined
       if (themeVal === 'light' || themeVal === 'dark' || themeVal === 'system') {
@@ -277,6 +286,9 @@ export const useUIStore = create<UIStore>((set, get) => ({
       const rightW = rightWRes?.data
       if (typeof rightW === 'number' && rightW >= 240 && rightW <= 600)
         patch.rightPanelWidth = rightW
+      const hdrKeyW = hdrKeyWRes?.data
+      if (typeof hdrKeyW === 'number' && hdrKeyW >= 15 && hdrKeyW <= 70)
+        patch.responseHeaderKeyWidth = hdrKeyW
       set(patch)
     } catch {
       /* noop */
@@ -293,6 +305,13 @@ export const useUIStore = create<UIStore>((set, get) => ({
     const { leftPanelWidth, rightPanelWidth } = get()
     void persistSetting('ui.leftPanelWidth', leftPanelWidth)
     void persistSetting('ui.rightPanelWidth', rightPanelWidth)
+  },
+
+  setResponseHeaderKeyWidth: (pct) =>
+    set({ responseHeaderKeyWidth: Math.max(15, Math.min(70, pct)) }),
+
+  commitResponseHeaderKeyWidth: () => {
+    void persistSetting('ui.responseHeaderKeyWidth', get().responseHeaderKeyWidth)
   },
 
   setSplitPosition: (position) => set({ splitPosition: Math.max(22, Math.min(78, position)) }),

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -412,6 +412,13 @@ export interface ApiResponse {
   statusText?: string
   headers?: Record<string, string>
   body?: string
+  /**
+   * Set to 'base64' when `body` holds a base64-encoded binary payload (image /
+   * PDF / octet-stream) rather than text — the response viewer then previews
+   * or offers it for download instead of rendering it in the text editor
+   * (issue #25). Absent for ordinary text responses.
+   */
+  bodyEncoding?: 'base64'
   bodySize?: number
   timing: ResponseTiming
   error?: string

--- a/tests/main/http-engine-binary-body.test.ts
+++ b/tests/main/http-engine-binary-body.test.ts
@@ -1,0 +1,61 @@
+/**
+ * issue #25 regression — binary / document response bodies.
+ *
+ * The engine used to fetch with responseType:'text', which ran every byte
+ * through UTF-8 decoding and corrupted images / PDFs / octet-stream payloads.
+ * It now fetches arraybuffer and base64-encodes binary content types while
+ * keeping text content types as plain UTF-8 strings (unchanged behaviour).
+ */
+import { describe, it, expect, afterAll, beforeAll } from 'vitest'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { executeHttpRequest } from '../../src/main/protocols/http.engine'
+
+// A buffer with bytes that are NOT valid UTF-8 (0x89, 0xFF, 0x00) — exactly
+// what UTF-8 decoding would have mangled. Mimics a PNG header.
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff, 0xfe, 0x01])
+
+let server: http.Server
+let base: string
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    if (req.url === '/image') {
+      res.setHeader('content-type', 'image/png')
+      res.end(PNG_BYTES)
+    } else if (req.url === '/pdf') {
+      res.setHeader('content-type', 'application/pdf')
+      res.end(PNG_BYTES) // bytes don't matter, only the content type branch
+    } else {
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ ok: true, ünïcode: 'çğşöü' }))
+    }
+  })
+  await new Promise<void>((r) => server.listen(0, r))
+  const { port } = server.address() as AddressInfo
+  base = `http://127.0.0.1:${port}`
+})
+
+afterAll(() => server.close())
+
+describe('http engine — binary response bodies (issue #25)', () => {
+  it('returns an image body as base64 that round-trips to the original bytes', async () => {
+    const res = await executeHttpRequest({ method: 'GET', url: `${base}/image` } as never)
+    expect(res.bodyEncoding).toBe('base64')
+    expect(res.bodySize).toBe(PNG_BYTES.length)
+    expect(Buffer.from(res.body ?? '', 'base64')).toEqual(PNG_BYTES)
+  })
+
+  it('flags application/pdf as base64 binary', async () => {
+    const res = await executeHttpRequest({ method: 'GET', url: `${base}/pdf` } as never)
+    expect(res.bodyEncoding).toBe('base64')
+  })
+
+  it('keeps a JSON/text body as a plain UTF-8 string (no bodyEncoding)', async () => {
+    const res = await executeHttpRequest({ method: 'GET', url: `${base}/json` } as never)
+    expect(res.bodyEncoding).toBeUndefined()
+    // Multi-byte UTF-8 characters survive intact, proving text decoding still works.
+    expect(res.body).toContain('çğşöü')
+    expect(JSON.parse(res.body ?? '{}')).toMatchObject({ ok: true })
+  })
+})

--- a/tests/renderer/key-value-bulk-toggle.test.tsx
+++ b/tests/renderer/key-value-bulk-toggle.test.tsx
@@ -1,0 +1,55 @@
+/// <reference types="react" />
+import * as React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+// JSX runtime shim (same as the other renderer tsx tests).
+;(globalThis as unknown as { React: typeof React }).React = React
+
+import KeyValueTable from '../../src/renderer/components/shared/KeyValueTable'
+import type { KeyValuePair } from '../../src/renderer/types'
+
+/**
+ * issue #22 — the Bulk Edit toggle moved out of its own spacer row into the
+ * table's Description header. This guards the relocation: the toggle must stay
+ * reachable in BOTH table and bulk-edit mode (otherwise the user could enter
+ * bulk mode and never get back), and the wasted spacer row above the table
+ * must be gone.
+ */
+describe('KeyValueTable — Bulk Edit toggle placement (issue #22)', () => {
+  const rows: KeyValuePair[] = [{ id: 'r1', key: 'a', value: '1', enabled: true }]
+
+  beforeEach(() => cleanup())
+
+  it('renders the toggle in the header (table mode) and round-trips to bulk mode and back', () => {
+    render(
+      <KeyValueTable
+        rows={rows}
+        onUpdate={vi.fn()}
+        onRemove={vi.fn()}
+        onAdd={vi.fn()}
+        onReplaceAll={vi.fn()}
+        flush
+      />,
+    )
+
+    // Table mode: toggle present, no textarea yet.
+    const toggle = screen.getByTestId('kv-bulk-toggle')
+    expect(toggle).toBeTruthy()
+    expect(screen.queryByTestId('kv-bulk-textarea')).toBeNull()
+
+    // Enter bulk mode → textarea shows AND the toggle is still reachable.
+    fireEvent.click(toggle)
+    expect(screen.getByTestId('kv-bulk-textarea')).toBeTruthy()
+    expect(screen.getByTestId('kv-bulk-toggle')).toBeTruthy()
+
+    // Back to table mode → textarea gone.
+    fireEvent.click(screen.getByTestId('kv-bulk-toggle'))
+    expect(screen.queryByTestId('kv-bulk-textarea')).toBeNull()
+  })
+
+  it('hides the toggle entirely when no onReplaceAll handler is provided', () => {
+    render(<KeyValueTable rows={rows} onUpdate={vi.fn()} onRemove={vi.fn()} onAdd={vi.fn()} />)
+    expect(screen.queryByTestId('kv-bulk-toggle')).toBeNull()
+  })
+})

--- a/tests/renderer/tab-edits-persistence.test.ts
+++ b/tests/renderer/tab-edits-persistence.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression coverage for the tab-editing data-loss + duplicate-selection bugs.
+ *
+ *   issue #23 — Query Params / Authorization / Body typed without clicking Save
+ *   were lost when the user clicked another API and came back. The tree-click /
+ *   open-tab paths run `openPreviewTab → switchToTab → loadFromEndpoint`; on a
+ *   re-focus `switchToTab` restored the in-memory edits but `loadFromEndpoint`
+ *   then clobbered them with the pristine DB row. The fix gates the DB reload on
+ *   the tab being clean — a dirty tab's working copy is authoritative.
+ *
+ *   issue #24 — after a few clicks two tabs rendered as the active tab. The
+ *   clean-preview-replace path kept the OLD slot id while swapping endpointId,
+ *   so `tab.id` stopped equalling `tab-${endpointId}`; re-opening the original
+ *   endpoint then minted a second tab whose `tab-${id}` collided with the stale
+ *   slot. The fix makes the replace adopt the incoming payload id (restoring the
+ *   invariant) plus an id-level dedup guard.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useRequestStore } from '../../src/renderer/stores/request.store'
+import { useTabsStore } from '../../src/renderer/stores/tabs.store'
+import type { Tab } from '../../src/renderer/types'
+
+function endpointTab(id: string, endpointId: string, name = endpointId): Tab {
+  return {
+    id,
+    name,
+    protocol: 'http',
+    method: 'GET',
+    url: '',
+    endpointId,
+    isDirty: false,
+    isLoading: false,
+    isPreview: false,
+  }
+}
+
+// ─── issue #23 — unsaved edits survive a re-focus ───────────────
+
+describe('request.store.loadFromEndpoint — preserves unsaved working copy (issue #23)', () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeTabId: null })
+    useRequestStore.setState({ _tabStates: new Map(), _currentTabId: null })
+  })
+
+  it('does NOT overwrite Query Params edited but not saved when the endpoint is re-opened', () => {
+    useTabsStore.setState({ tabs: [endpointTab('tab-A', 'A')], activeTabId: 'tab-A' })
+    const rs = useRequestStore.getState()
+    rs.switchToTab('tab-A')
+
+    // Fresh open hydrates from the DB row.
+    rs.loadFromEndpoint({
+      method: 'GET',
+      url: 'http://api/a',
+      params: [{ id: 'p0', key: 'orig', value: '1', enabled: true }],
+    })
+    expect(useRequestStore.getState().params[0].key).toBe('orig')
+
+    // User edits the params without saving → tab goes dirty.
+    useRequestStore.getState().setParams([{ id: 'p1', key: 'edited', value: '2', enabled: true }])
+    expect(useTabsStore.getState().tabs[0].isDirty).toBe(true)
+
+    // Re-focus replays the open sequence: switchToTab restores the edits, then
+    // loadFromEndpoint is handed the pristine DB row again.
+    useRequestStore.getState().switchToTab('tab-A')
+    useRequestStore.getState().loadFromEndpoint({
+      method: 'GET',
+      url: 'http://api/a',
+      params: [{ id: 'p0', key: 'orig', value: '1', enabled: true }],
+    })
+
+    // The edits win — the DB reload was skipped because the tab is dirty.
+    const params = useRequestStore.getState().params
+    expect(params).toHaveLength(1)
+    expect(params[0].key).toBe('edited')
+  })
+
+  it('still hydrates from the DB row on a fresh (clean) open', () => {
+    useTabsStore.setState({ tabs: [endpointTab('tab-B', 'B')], activeTabId: 'tab-B' })
+    const rs = useRequestStore.getState()
+    rs.switchToTab('tab-B')
+
+    rs.loadFromEndpoint({
+      method: 'POST',
+      url: 'http://api/b',
+      params: [{ id: 'pb', key: 'fromdb', value: '9', enabled: true }],
+    })
+
+    expect(useRequestStore.getState().url).toBe('http://api/b')
+    expect(useRequestStore.getState().params[0].key).toBe('fromdb')
+  })
+})
+
+// ─── issue #24 — never two tabs sharing the active id ───────────
+
+describe('tabs.store.openPreviewTab — no duplicate-id / double-active tab (issue #24)', () => {
+  beforeEach(() => {
+    useTabsStore.setState({ tabs: [], activeTabId: null })
+  })
+
+  it('keeps tab.id ≡ tab-${endpointId} and never mints two tabs with one id', () => {
+    const open = (id: string, endpointId: string, name: string) =>
+      useTabsStore.getState().openPreviewTab({
+        id,
+        name,
+        protocol: 'http',
+        method: 'GET',
+        url: `/${endpointId}`,
+        endpointId,
+      })
+
+    // 1. Endpoint A opens as a preview.
+    open('tab-A', 'A', 'Updates a pet')
+    // 2. Endpoint B replaces the clean preview — the slot must adopt tab-B,
+    //    NOT keep tab-A (the old decoupling bug).
+    open('tab-B', 'B', 'Finds pets by status')
+    let tabs = useTabsStore.getState().tabs
+    expect(tabs).toHaveLength(1)
+    expect(tabs[0].id).toBe('tab-B')
+    expect(tabs[0].endpointId).toBe('B')
+
+    // 3. Edit the preview so the next open pins it instead of replacing.
+    useTabsStore.getState().markDirty('tab-B', true)
+
+    // 4. Re-open endpoint A: B pins, a fresh A preview opens. No id collision.
+    open('tab-A', 'A', 'Updates a pet')
+    tabs = useTabsStore.getState().tabs
+    const ids = tabs.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+
+    // Exactly one tab carries the active id → only one renders as selected.
+    const activeId = useTabsStore.getState().activeTabId
+    expect(tabs.filter((t) => t.id === activeId)).toHaveLength(1)
+    // Both endpoints are still present, each on its own physical tab.
+    expect(tabs.find((t) => t.endpointId === 'A')).toBeDefined()
+    expect(tabs.find((t) => t.endpointId === 'B')).toBeDefined()
+  })
+})

--- a/tests/renderer/ui-panel-width.test.ts
+++ b/tests/renderer/ui-panel-width.test.ts
@@ -34,3 +34,23 @@ describe('ui.store panel widths (issue #15)', () => {
     expect(() => useUIStore.getState().commitPanelWidths()).not.toThrow()
   })
 })
+
+describe('ui.store response Headers column width (issue #20)', () => {
+  beforeEach(() => {
+    useUIStore.setState({ responseHeaderKeyWidth: 35 })
+  })
+
+  it('setResponseHeaderKeyWidth clamps to [15, 70] percent', () => {
+    useUIStore.getState().setResponseHeaderKeyWidth(50)
+    expect(useUIStore.getState().responseHeaderKeyWidth).toBe(50)
+    useUIStore.getState().setResponseHeaderKeyWidth(5)
+    expect(useUIStore.getState().responseHeaderKeyWidth).toBe(15)
+    useUIStore.getState().setResponseHeaderKeyWidth(95)
+    expect(useUIStore.getState().responseHeaderKeyWidth).toBe(70)
+  })
+
+  it('commitResponseHeaderKeyWidth does not throw without a settings bridge', () => {
+    useUIStore.getState().setResponseHeaderKeyWidth(42)
+    expect(() => useUIStore.getState().commitResponseHeaderKeyWidth()).not.toThrow()
+  })
+})

--- a/website/src/content/docs/changelog.md
+++ b/website/src/content/docs/changelog.md
@@ -10,6 +10,37 @@ source of truth for release descriptions — the CI release job mirrors
 each entry into the matching [GitHub Release](https://github.com/apinizer/testnizer/releases),
 where signed installers and SHA-256 checksums are attached.
 
+## v1.4.31
+
+**A UX-polish and reliability release — your unsaved edits stay put, the tab
+strip stops double-selecting, binary responses are finally viewable, and the
+request/response panes line up.** Closes eleven reported issues.
+
+**Request editing & tabs.** Query Params, Authorization and Body values typed
+without clicking Save are no longer lost when you click another API and come
+back — each tab keeps its working copy, matching Postman / Insomnia (#23). The
+tab strip no longer shows two tabs both highlighted as active after a few clicks
+(#24).
+
+**Request & response layout.** The Params and Headers tables drop their rounded
+"card" border and side padding so they sit flush against the pane, pairing with
+the borderless response Body / Headers (#21). The Bulk Edit toggle moved into
+the table's Description header instead of an empty spacer row (#22). The response
+Headers count is now a green pill matching the request badge (#19).
+
+**Response viewer.** Images, PDFs, audio/video and other binary bodies — which
+used to show as garbage — now preview inline (or in a frame) with a Download
+button (#25). The response Headers KEY / VALUE columns are draggable, with the
+width remembered across tab switches (#20).
+
+**Runner & import (rolled up).** A request with passing assertions is no longer
+force-failed just because the HTTP status was ≥ 400 (#16). Imports stop
+duplicating a query param present in both the URL and the Params table
+(`?type=snmp&type=snmp`), common with Insomnia (#17). The left APIs tree and
+right Variables pane are resizable, with persisted widths (#15). Added a
+regression guard for `pm.response.json()` / `.body` in after-response scripts on
+the Run path (#18).
+
 ## v1.4.30
 
 **Signed installers on Windows and macOS — no more "unknown publisher" /

--- a/website/src/content/docs/tr/changelog.md
+++ b/website/src/content/docs/tr/changelog.md
@@ -11,6 +11,38 @@ girdiyi karşılığı olan [GitHub Release](https://github.com/apinizer/testniz
 sayfasına aynalar; imzalı yükleyiciler ve SHA-256 sağlama toplamları
 orada eklenir.
 
+## v1.4.31
+
+**UX cilası ve güvenilirlik sürümü — kaydedilmemiş düzenlemeleriniz yerinde
+kalıyor, sekme şeridi çift seçim yapmıyor, binary yanıtlar nihayet
+görüntülenebiliyor ve istek/yanıt panelleri hizalanıyor.** On bir bildirilen
+sorunu kapatır.
+
+**İstek düzenleme & sekmeler.** Save'e basmadan girilen Query Params,
+Authorization ve Body değerleri, başka bir API'ye tıklayıp geri dönünce artık
+kaybolmuyor — her sekme kendi çalışma kopyasını koruyor (Postman / Insomnia gibi)
+(#23). Sekme şeridi birkaç tıklamadan sonra iki sekmeyi aynı anda seçili
+göstermiyor (#24).
+
+**İstek & yanıt düzeni.** Params ve Headers tabloları yuvarlak "kart"
+kenarlığını ve yan boşluğunu bıraktı; kenarlıksız yanıt Body / Headers ile
+eşleşecek şekilde panele dayanıyor (#21). Bulk Edit düğmesi, boş bir ara satır
+yerine tablonun Description başlığına taşındı (#22). Yanıt Headers sayısı, istek
+rozetiyle eşleşen yeşil bir pill oldu (#19).
+
+**Yanıt görüntüleyici.** Daha önce bozuk görünen görseller, PDF'ler, ses/video
+ve diğer binary gövdeler artık satır içinde (veya bir çerçevede) Download
+düğmesiyle önizleniyor (#25). Yanıt Headers KEY / VALUE kolonları sürüklenebilir
+ve genişlik sekme değişiminde korunuyor (#20).
+
+**Runner & içe aktarma (toplu dahil edildi).** Assertion'ları geçen bir istek,
+yalnızca HTTP durumu ≥ 400 diye artık zorla başarısız sayılmıyor (#16). İçe
+aktarmalar, hem URL'de hem Params tablosunda bulunan bir query parametresini
+ikiye katlamayı bıraktı (`?type=snmp&type=snmp`; Insomnia'da yaygın) (#17). Sol
+API ağacı ve sağ Variables paneli yeniden boyutlandırılabilir, genişlikler
+korunuyor (#15). Run yolundaki after-response script'lerde `pm.response.json()` /
+`.body` için bir regresyon koruması eklendi (#18).
+
 ## v1.4.30
 
 **Windows ve macOS'ta imzalı kurulumlar — artık "bilinmeyen yayıncı" /

--- a/website/src/lib/latest-release.ts
+++ b/website/src/lib/latest-release.ts
@@ -46,8 +46,8 @@ export interface RepoStats {
 }
 
 const FALLBACK: LatestRelease = {
-  tag: 'v1.4.30',
-  version: '1.4.30',
+  tag: 'v1.4.31',
+  version: '1.4.31',
   htmlUrl: 'https://github.com/apinizer/testnizer/releases/latest',
   publishedAt: null,
   assets: [],


### PR DESCRIPTION
Fixes the seven newly-reported UI/UX issues plus rolls up the previously-merged
runner/import/layout fixes that haven't shipped yet.

## Request editing & tabs
- **issue #23** — unsaved Query Params / Authorization / Body are preserved when
  switching APIs and back (per-tab working copy is authoritative; the DB reload
  is skipped while a tab is dirty).
- **issue #24** — no more two tabs both rendered active: the preview-tab reuse
  now keeps `tab.id ≡ tab-${resourceId}`, plus an id-level dedup guard.

## Request & response layout
- **issue #21** — Params / Headers tables are flush (no card border / side
  padding), pairing with the response panes.
- **issue #22** — Bulk Edit moved into the table Description header (no spacer
  gap); reachable in both table and bulk mode.
- **issue #19** — response Headers count is a green pill matching the request
  badge.

## Response viewer
- **issue #25** — binary / document responses (images, PDF, audio/video,
  octet-stream) preview inline / in a frame with a Download button; the engine
  fetches arraybuffer and base64-encodes binary content types.
- **issue #20** — response Headers KEY/VALUE columns are draggable, width
  persisted.

## Rolled up (merged after v1.4.30, not yet released)
- **issue #16** — runner pass/fail follows assertions, not raw HTTP status.
- **issue #17** — imports stop duplicating a query param carried in both URL and
  Params table.
- **issue #15** — resizable left/right side panels.
- **issue #18** — regression guard for `pm.response` body on the Run path.

## Tests
New regressions: `tab-edits-persistence`, `key-value-bulk-toggle`,
`http-engine-binary-body`, `ui-panel-width`. Full unit suite green (1931
passing); typecheck clean; dev app boots clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
