### PR TITLE
feat(updater): wire the auto-check / auto-download toggles

### DIFF
--- a/docs/release-notes/v1.4.33.md
+++ b/docs/release-notes/v1.4.33.md
@@ -1,0 +1,17 @@
+## v1.4.33
+
+**Automatic updates now actually run.**
+
+- **Auto-update wiring:** the *Automatically check for updates* and
+  *Automatically download updates* settings were saved but read by nothing — the
+  app only updated when you opened Settings and clicked *Check for updates*. They
+  now work end to end: the app checks for a newer version shortly after launch
+  and every few hours, automatically downloads it when that toggle is on, and
+  opens the update dialog when one is found so you can install with one click. A
+  check is skipped while you're offline or once an update has already been found.
+  (macOS builds are Developer ID signed + notarized and Windows builds are Certum
+  signed, so the in-app download-and-install path works on both — only the
+  toggles were missing.)
+
+**Tests:** auto-download-on-available coverage (toggle on/off, and no
+double-trigger on a repeated event).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testnizer",
   "productName": "Testnizer",
-  "version": "1.4.32",
+  "version": "1.4.33",
   "description": "Testnizer — Cross-platform desktop API testing application",
   "main": "./out/main/index.js",
   "homepage": "https://www.testnizer.com",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,12 +4,18 @@ import AppShell from './components/layout/AppShell'
 import AboutModal from './components/modals/AboutModal'
 import EulaConsentGate from './components/eula/EulaConsentGate'
 import { useUIStore } from './stores/ui.store'
+import { useWorkspaceStore } from './stores/workspace.store'
 import { initUpdaterListeners } from './stores/updater.store'
 import { initConsoleListeners } from './stores/console.store'
+import { useAutoUpdater } from './lib/use-auto-updater'
 
 function App(): React.JSX.Element {
   const hydrateFromSettings = useUIStore((s) => s.hydrateFromSettings)
   const setShowAboutModal = useUIStore((s) => s.setShowAboutModal)
+  // Drive the "Automatically check / download updates" toggles from the active
+  // project's settings (previously inert — nothing read them).
+  const activeProjectId = useWorkspaceStore((s) => s.activeProjectId)
+  useAutoUpdater(activeProjectId)
   useEffect(() => {
     void hydrateFromSettings()
     const cleanupUpdater = initUpdaterListeners()

--- a/src/renderer/lib/use-auto-updater.ts
+++ b/src/renderer/lib/use-auto-updater.ts
@@ -1,0 +1,90 @@
+import { useEffect } from 'react'
+import { useUpdaterStore } from '../stores/updater.store'
+import { useUIStore } from '../stores/ui.store'
+
+/**
+ * Drives the "Automatically check / download updates" toggles, which were
+ * previously inert — saved in project settings but read by nothing, so the app
+ * only ever updated when the user opened Settings and clicked "Check for
+ * updates" (user-reported: "both options checked but auto-update doesn't
+ * happen").
+ *
+ * Wiring lives in the renderer to mirror the existing manual flow (which already
+ * drives `check()` / `download()` over IPC); the main process leaves
+ * autoDownload off and does no polling of its own.
+ *
+ * Scope: update prefs live in per-project settings (`project.<id>.settings`), so
+ * we read the ACTIVE project's toggles and re-read them whenever the active
+ * project changes. Offline-first is preserved — a check is skipped while the OS
+ * reports no connection.
+ */
+
+const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000 // re-check every 6h while the app runs
+const INITIAL_CHECK_DELAY_MS = 4000 // let the project finish loading before hitting the network
+
+interface UpdatePrefs {
+  autoCheckUpdates?: boolean
+  autoDownloadUpdates?: boolean
+}
+
+function runCheck(): void {
+  // Offline-first: never reach out when the OS reports no connection.
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) return
+  const s = useUpdaterStore.getState()
+  // Once an update has been found (available/downloading/ready) there's nothing
+  // to gain from re-checking until the app restarts — and skipping it stops the
+  // periodic timer from re-opening a modal the user already dismissed.
+  if (s.status === 'available' || s.status === 'downloading' || s.status === 'ready') return
+  s.check()
+}
+
+export function useAutoUpdater(activeProjectId: string | null): void {
+  useEffect(() => {
+    if (!activeProjectId) return
+    let cancelled = false
+    let initial: ReturnType<typeof setTimeout> | undefined
+    let interval: ReturnType<typeof setInterval> | undefined
+
+    void (async () => {
+      let prefs: UpdatePrefs = {}
+      try {
+        const res = (await window.api?.settings?.get(`project.${activeProjectId}.settings`)) as
+          | { success: boolean; data?: UpdatePrefs }
+          | undefined
+        if (res?.success && res.data) prefs = res.data
+      } catch {
+        // Settings unreadable → fall through to defaults below.
+      }
+      if (cancelled) return
+
+      // Defaults match DEFAULT_SETTINGS in ProjectDetailModal: check on, download off.
+      const autoCheck = prefs.autoCheckUpdates ?? true
+      const autoDownload = prefs.autoDownloadUpdates ?? false
+      useUpdaterStore.getState().setAutoDownload(autoDownload)
+
+      if (!autoCheck) return
+      initial = setTimeout(runCheck, INITIAL_CHECK_DELAY_MS)
+      interval = setInterval(runCheck, CHECK_INTERVAL_MS)
+    })()
+
+    return () => {
+      cancelled = true
+      if (initial) clearTimeout(initial)
+      if (interval) clearInterval(interval)
+    }
+  }, [activeProjectId])
+
+  // A background check/download is otherwise invisible — the UpdateModal only
+  // opens when the user opens it. Surface a background-found update by opening
+  // that same modal (reusing its download / restart actions) the first time the
+  // status reaches 'available' or 'ready', unless the user already has it open
+  // (the manual flow drives those states itself). Registered once.
+  useEffect(() => {
+    return useUpdaterStore.subscribe((state, prev) => {
+      if (state.status === prev.status) return
+      if (state.status !== 'available' && state.status !== 'ready') return
+      const ui = useUIStore.getState()
+      if (!ui.showUpdateModal) ui.setShowUpdateModal(true)
+    })
+  }, [])
+}

--- a/src/renderer/stores/updater.store.ts
+++ b/src/renderer/stores/updater.store.ts
@@ -19,6 +19,14 @@ interface UpdaterStore {
   releaseNotes: string | null
   downloadPercent: number
   errorMessage: string | null
+  /**
+   * Mirror of the project's "Automatically download updates" toggle. Set by the
+   * useAutoUpdater hook from the active project's settings; read in
+   * initUpdaterListeners when an update becomes available to decide whether to
+   * start the download without the user clicking. Defaults false so the manual
+   * flow never downloads unasked.
+   */
+  autoDownload: boolean
 
   check: () => void
   download: () => void
@@ -29,6 +37,7 @@ interface UpdaterStore {
   setReleaseNotes: (notes: string) => void
   setDownloadPercent: (percent: number) => void
   setError: (message: string) => void
+  setAutoDownload: (enabled: boolean) => void
 }
 
 export const useUpdaterStore = create<UpdaterStore>((set) => ({
@@ -37,6 +46,7 @@ export const useUpdaterStore = create<UpdaterStore>((set) => ({
   releaseNotes: null,
   downloadPercent: 0,
   errorMessage: null,
+  autoDownload: false,
 
   check: () => {
     set({ status: 'checking', errorMessage: null })
@@ -113,6 +123,7 @@ export const useUpdaterStore = create<UpdaterStore>((set) => ({
   setReleaseNotes: (notes) => set({ releaseNotes: notes }),
   setDownloadPercent: (percent) => set({ downloadPercent: percent }),
   setError: (message) => set({ status: 'error', errorMessage: message }),
+  setAutoDownload: (enabled) => set({ autoDownload: enabled }),
 }))
 
 /**
@@ -148,6 +159,14 @@ export function initUpdaterListeners(): (() => void) | undefined {
               .join('<hr/>')
             if (joined) store.setReleaseNotes(joined)
           }
+        }
+        // Kick off the download automatically when the user enabled
+        // "Automatically download updates". Without this the toggle was inert —
+        // the update sat at "available" until the user opened Settings and
+        // clicked Download. Guard on status so a redundant 'available' (e.g. a
+        // re-check) doesn't restart an in-flight download.
+        if (store.autoDownload && store.status !== 'downloading' && store.status !== 'ready') {
+          store.download()
         }
         break
       case 'not-available':

--- a/tests/renderer/updater-store.test.ts
+++ b/tests/renderer/updater-store.test.ts
@@ -44,6 +44,7 @@ describe('updater store — event → status mapping', () => {
       releaseNotes: null,
       downloadPercent: 0,
       errorMessage: null,
+      autoDownload: false,
     })
   })
   afterEach(() => {
@@ -103,5 +104,86 @@ describe('updater store — event → status mapping', () => {
     vi.advanceTimersByTime(1600)
     expect(useUpdaterStore.getState().status).toBe('available')
     vi.useRealTimers()
+  })
+})
+
+describe('updater store — auto-download on available', () => {
+  let savedApi: unknown
+  let cleanup: (() => void) | undefined
+
+  function installFakeApiWithDownload(): {
+    emit: (e: UpdaterEvent) => void
+    download: ReturnType<typeof vi.fn>
+  } {
+    let cb: ((e: UpdaterEvent) => void) | null = null
+    const download = vi.fn(() => Promise.resolve({ success: true }))
+    ;(window as unknown as { api?: unknown }).api = {
+      updater: {
+        onEvent: (callback: (e: UpdaterEvent) => void) => {
+          cb = callback
+          return () => {
+            cb = null
+          }
+        },
+        download,
+      },
+    }
+    return {
+      emit: (e: UpdaterEvent) => {
+        if (!cb) throw new Error('no updater callback registered')
+        cb(e)
+      },
+      download,
+    }
+  }
+
+  beforeEach(() => {
+    savedApi = (window as unknown as { api?: unknown }).api
+    useUpdaterStore.setState({
+      status: 'idle',
+      version: null,
+      releaseNotes: null,
+      downloadPercent: 0,
+      errorMessage: null,
+      autoDownload: false,
+    })
+  })
+  afterEach(() => {
+    cleanup?.()
+    cleanup = undefined
+    ;(window as unknown as { api?: unknown }).api = savedApi
+  })
+
+  it('auto-starts the download on "available" when autoDownload is on', () => {
+    const bus = installFakeApiWithDownload()
+    cleanup = initUpdaterListeners()
+    useUpdaterStore.getState().setAutoDownload(true)
+
+    bus.emit({ type: 'available', version: '9.9.9' })
+
+    expect(bus.download).toHaveBeenCalledTimes(1)
+    expect(useUpdaterStore.getState().status).toBe('downloading')
+  })
+
+  it('leaves it at "available" when autoDownload is off (manual flow unchanged)', () => {
+    const bus = installFakeApiWithDownload()
+    cleanup = initUpdaterListeners()
+    useUpdaterStore.getState().setAutoDownload(false)
+
+    bus.emit({ type: 'available', version: '9.9.9' })
+
+    expect(bus.download).not.toHaveBeenCalled()
+    expect(useUpdaterStore.getState().status).toBe('available')
+  })
+
+  it('does not restart an in-flight download on a redundant "available"', () => {
+    const bus = installFakeApiWithDownload()
+    cleanup = initUpdaterListeners()
+    useUpdaterStore.getState().setAutoDownload(true)
+
+    bus.emit({ type: 'available', version: '9.9.9' }) // → downloading, 1 call
+    bus.emit({ type: 'available', version: '9.9.9' }) // redundant — must not re-trigger
+
+    expect(bus.download).toHaveBeenCalledTimes(1)
   })
 })

--- a/website/src/content/docs/changelog.md
+++ b/website/src/content/docs/changelog.md
@@ -10,6 +10,20 @@ source of truth for release descriptions — the CI release job mirrors
 each entry into the matching [GitHub Release](https://github.com/apinizer/testnizer/releases),
 where signed installers and SHA-256 checksums are attached.
 
+## v1.4.33
+
+**Automatic updates now actually run.**
+
+The *Automatically check for updates* and *Automatically download updates*
+settings were saved but read by nothing — the app only updated when you opened
+Settings and clicked *Check for updates*. They now work end to end: the app
+checks for a newer version shortly after launch and every few hours,
+automatically downloads it when that toggle is on, and opens the update dialog
+when one is found so you can install with one click. A check is skipped while
+you're offline or once an update has already been found. (macOS builds are
+Developer ID signed + notarized and Windows builds are Certum signed, so the
+in-app download-and-install path works on both — only the toggles were missing.)
+
 ## v1.4.32
 
 **Imported test suites now run end-to-end, your open tabs survive an app

--- a/website/src/content/docs/tr/changelog.md
+++ b/website/src/content/docs/tr/changelog.md
@@ -11,6 +11,21 @@ girdiyi karşılığı olan [GitHub Release](https://github.com/apinizer/testniz
 sayfasına aynalar; imzalı yükleyiciler ve SHA-256 sağlama toplamları
 orada eklenir.
 
+## v1.4.33
+
+**Otomatik güncellemeler artık gerçekten çalışıyor.**
+
+*Otomatik güncelleme kontrolü* ve *Güncellemeleri otomatik indir* ayarları
+kaydediliyor ama hiçbir şey tarafından okunmuyordu — uygulama yalnızca Ayarlar'ı
+açıp *Güncellemeleri denetle*'ye bastığınızda güncelleniyordu. Artık uçtan uca
+çalışıyor: uygulama açılıştan kısa süre sonra ve birkaç saatte bir yeni sürüm
+kontrol ediyor, o seçenek açıkken otomatik indiriyor ve bir güncelleme bulununca
+güncelleme penceresini açıyor; tek tıkla kurabiliyorsunuz. Çevrimdışıyken veya
+güncelleme zaten bulunmuşken kontrol atlanıyor. (macOS derlemeleri Developer ID
+ile imzalı + notarized, Windows derlemeleri Certum imzalı — yani uygulama içi
+indir-ve-kur yolu ikisinde de çalışıyor; eksik olan yalnızca düğmelerin
+bağlanmasıydı.)
+
 ## v1.4.32
 
 **İçe aktarılan test suite'leri artık uçtan uca çalışıyor, açık sekmeleriniz

--- a/website/src/lib/latest-release.ts
+++ b/website/src/lib/latest-release.ts
@@ -46,8 +46,8 @@ export interface RepoStats {
 }
 
 const FALLBACK: LatestRelease = {
-  tag: 'v1.4.32',
-  version: '1.4.32',
+  tag: 'v1.4.33',
+  version: '1.4.33',
   htmlUrl: 'https://github.com/apinizer/testnizer/releases/latest',
   publishedAt: null,
   assets: [],


### PR DESCRIPTION
Fixes the user-reported "both update options checked but auto-update doesn't happen". The toggles were saved in project settings but read by nothing, and the main process disables its own polling — so the app only updated on a manual "Check for updates".

- `useAutoUpdater` hook reads the active project's update prefs → initial check after load + 6h interval (skips while offline or once an update is found).
- updater store gains `autoDownload`; on `available` it auto-starts the download when the toggle is on (guarded against restarting an in-flight one). Manual flow unchanged.
- A background-found update opens the existing UpdateModal so the silent path isn't invisible.

Signing is not the blocker — mac builds are Developer ID signed + notarized (confirmed on installed v1.4.30 and the v1.4.32 build).

Test: updater-store auto-download on available (on/off + no double-trigger). Full unit suite green, typecheck clean, dev boot verified.