### PR TITLE
fix(engine): per-request Authorization header wins over inherited auth (issue #48)

### DIFF
--- a/docs/release-notes/v1.4.35.md
+++ b/docs/release-notes/v1.4.35.md
@@ -1,0 +1,21 @@
+## v1.4.35
+
+**The Collection Runner now sends each request's own Authorization header
+instead of an inherited management token.**
+
+- **Per-request auth wins (issue #48):** in a multi-step run, a setup step's
+  management access token (e.g. `Bearer apnz_…`) is inherited as the
+  collection / folder auth. Later requests that declare their **own**
+  Authorization header — a gateway introspect with `Basic client_id:secret`, or
+  a regenerate with a freshly minted `Bearer eyJ…` JWT — no longer have that
+  header silently overwritten by the inherited token. The request's own
+  credential now reaches the server (matching Insomnia / Postman), so introspect
+  no longer fails with *Missing Parameter: client_id* and JWT regenerate no
+  longer fails with *Invalid JWT serialization*. Only the Basic-auth path guarded
+  against this before; the guard now covers Bearer, OAuth 2.0, API-key, and Hawk
+  auth too — a single fix in the HTTP engine, so both Send and Run behave the
+  same.
+
+**Tests:** five engine cases assert the request's own Authorization header
+reaches the wire over an inherited token — the exact `apnz_` Bearer scenario, a
+lower-cased `Basic` header, OAuth 2.0, API-key (same-named header), and Hawk.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testnizer",
-  "version": "1.4.18",
+  "version": "1.4.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "testnizer",
-      "version": "1.4.18",
+      "version": "1.4.35",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testnizer",
   "productName": "Testnizer",
-  "version": "1.4.34",
+  "version": "1.4.35",
   "description": "Testnizer — Cross-platform desktop API testing application",
   "main": "./out/main/index.js",
   "homepage": "https://www.testnizer.com",

--- a/src/main/protocols/http.engine.ts
+++ b/src/main/protocols/http.engine.ts
@@ -426,6 +426,22 @@ async function ensureOAuth2Token(auth: AuthConfig | undefined): Promise<void> {
   o.token = res.accessToken
 }
 
+/**
+ * True when the request already carries a header named `name` (case-insensitive)
+ * that the user set explicitly in the Headers tab. Auth-tab / inherited auth must
+ * defer to it: a per-request `Authorization` header wins over any
+ * collection/folder/environment auth, matching Insomnia/Postman (issue #48). The
+ * `basic` case has enforced this since v1.4.4; this generalizes it to every
+ * Authorization-setting auth type so an inherited management Bearer can't clobber
+ * a request's own header (e.g. a gateway step's `Basic client_id:secret` or a
+ * freshly minted `Bearer eyJ…` JWT).
+ */
+function hasExplicitHeader(config: AxiosRequestConfig, name: string): boolean {
+  if (!config.headers) return false
+  const lower = name.toLowerCase()
+  return Object.keys(config.headers).some((k) => k.toLowerCase() === lower)
+}
+
 function applyAuth(
   config: AxiosRequestConfig,
   auth: AuthConfig,
@@ -464,10 +480,7 @@ function applyAuth(
         // explicit header win — preserve that order so a deliberate
         // manual header isn't silently overridden by the auth config.
         config.headers = config.headers || {}
-        const existing = Object.keys(config.headers).some(
-          (k) => k.toLowerCase() === 'authorization',
-        )
-        if (!existing) {
+        if (!hasExplicitHeader(config, 'Authorization')) {
           const token = Buffer.from(`${username}:${password}`).toString('base64')
           config.headers['Authorization'] = `Basic ${token}`
         }
@@ -476,9 +489,13 @@ function applyAuth(
     }
     case 'bearer': {
       if (auth.bearer) {
-        const prefix = auth.bearer.prefix || 'Bearer'
         config.headers = config.headers || {}
-        config.headers['Authorization'] = `${prefix} ${auth.bearer.token}`
+        // Per-request Authorization header wins over an inherited/auth-tab
+        // Bearer (issue #48) — same guard as basic above.
+        if (!hasExplicitHeader(config, 'Authorization')) {
+          const prefix = auth.bearer.prefix || 'Bearer'
+          config.headers['Authorization'] = `${prefix} ${auth.bearer.token}`
+        }
       }
       break
     }
@@ -486,7 +503,10 @@ function applyAuth(
       if (auth.apiKey) {
         if (auth.apiKey.in === 'header') {
           config.headers = config.headers || {}
-          config.headers[auth.apiKey.key] = auth.apiKey.value
+          // Don't overwrite a same-named header the request already declares.
+          if (!hasExplicitHeader(config, auth.apiKey.key)) {
+            config.headers[auth.apiKey.key] = auth.apiKey.value
+          }
         } else {
           config.params = config.params || {}
           ;(config.params as Record<string, string>)[auth.apiKey.key] = auth.apiKey.value
@@ -497,7 +517,9 @@ function applyAuth(
     case 'oauth2': {
       if (auth.oauth2?.token) {
         config.headers = config.headers || {}
-        config.headers['Authorization'] = `Bearer ${auth.oauth2.token}`
+        if (!hasExplicitHeader(config, 'Authorization')) {
+          config.headers['Authorization'] = `Bearer ${auth.oauth2.token}`
+        }
       }
       break
     }
@@ -509,15 +531,17 @@ function applyAuth(
     }
     case 'hawk': {
       if (auth.hawk) {
-        const hawkHeader = generateHawkHeader(
-          method,
-          url,
-          auth.hawk.authId,
-          auth.hawk.authKey,
-          auth.hawk.algorithm,
-        )
         config.headers = config.headers || {}
-        config.headers['Authorization'] = hawkHeader
+        if (!hasExplicitHeader(config, 'Authorization')) {
+          const hawkHeader = generateHawkHeader(
+            method,
+            url,
+            auth.hawk.authId,
+            auth.hawk.authKey,
+            auth.hawk.algorithm,
+          )
+          config.headers['Authorization'] = hawkHeader
+        }
       }
       break
     }

--- a/tests/main/http-engine-auth.test.ts
+++ b/tests/main/http-engine-auth.test.ts
@@ -43,7 +43,8 @@ let port = 0
 let captured: Captured | null = null
 // When set, this overrides the default 200 handler (used for the digest
 // challenge test). Return `true` if it fully handled the response.
-let customHandler: ((cap: Captured, res: import('node:http').ServerResponse) => boolean) | null = null
+let customHandler: ((cap: Captured, res: import('node:http').ServerResponse) => boolean) | null =
+  null
 
 beforeAll(
   () =>
@@ -159,6 +160,37 @@ describe('http.engine auth — bearer', () => {
     })
     expect(captured?.headers.authorization).toBe('Token xyz')
   })
+
+  // issue #48: a per-request Authorization header must win over an
+  // inherited/auth-tab Bearer. In the Runner a setup step's management Bearer is
+  // resolved as the effective auth; the gateway request declares its own header
+  // and that header must reach the wire, not the inherited token.
+  it('does not clobber an explicit Authorization header set in Headers tab', async () => {
+    reset()
+    await executeHttpRequest({
+      method: 'GET',
+      url: baseUrl('/bearer'),
+      headers: [{ id: '1', key: 'Authorization', value: 'Bearer eyJ.header.wins', enabled: true }],
+      auth: { type: 'bearer', bearer: { token: 'apnz_inherited_management_token' } },
+      timeout: 3000,
+    })
+    expect(captured?.headers.authorization).toBe('Bearer eyJ.header.wins')
+  })
+
+  // Same class, case-insensitive: an inherited Bearer must not clobber a
+  // lower-cased `authorization: Basic …` the gateway request declares.
+  it('lets a lower-cased Basic authorization header win over an inherited Bearer', async () => {
+    reset()
+    const basic = 'Basic ' + Buffer.from('client_id:client_secret').toString('base64')
+    await executeHttpRequest({
+      method: 'POST',
+      url: baseUrl('/introspect'),
+      headers: [{ id: '1', key: 'authorization', value: basic, enabled: true }],
+      auth: { type: 'bearer', bearer: { token: 'apnz_inherited_management_token' } },
+      timeout: 3000,
+    })
+    expect(captured?.headers.authorization).toBe(basic)
+  })
 })
 
 // ─── api-key ─────────────────────────────────────────────────
@@ -189,6 +221,19 @@ describe('http.engine auth — api-key', () => {
     // Not added as a header.
     expect(captured?.headers['api_key']).toBeUndefined()
   })
+
+  // issue #48 (same class): an explicit same-named header wins over api-key auth.
+  it('does not clobber a same-named header the request already declares', async () => {
+    reset()
+    await executeHttpRequest({
+      method: 'GET',
+      url: baseUrl('/apikey'),
+      headers: [{ id: '1', key: 'X-Api-Key', value: 'request-own', enabled: true }],
+      auth: { type: 'api-key', apiKey: { key: 'X-Api-Key', value: 'inherited', in: 'header' } },
+      timeout: 3000,
+    })
+    expect(captured?.headers['x-api-key']).toBe('request-own')
+  })
 })
 
 // ─── oauth2 ──────────────────────────────────────────────────
@@ -203,6 +248,20 @@ describe('http.engine auth — oauth2', () => {
       timeout: 3000,
     })
     expect(captured?.headers.authorization).toBe('Bearer oauth-access-token')
+  })
+
+  // issue #48 (same class): a per-request Authorization header wins over an
+  // oauth2 access token resolved from the auth tab / inheritance.
+  it('does not clobber an explicit Authorization header set in Headers tab', async () => {
+    reset()
+    await executeHttpRequest({
+      method: 'GET',
+      url: baseUrl('/oauth2'),
+      headers: [{ id: '1', key: 'Authorization', value: 'Bearer request-own', enabled: true }],
+      auth: { type: 'oauth2', oauth2: { token: 'inherited-oauth-token' } },
+      timeout: 3000,
+    })
+    expect(captured?.headers.authorization).toBe('Bearer request-own')
   })
 })
 
@@ -457,7 +516,11 @@ describe('http.engine auth — hawk', () => {
       url: baseUrl('/hawk/resource?a=1'),
       auth: {
         type: 'hawk',
-        hawk: { authId: 'dh37fgj492je', authKey: 'werxhqb98rpaxn39848xrunpaw3489ru', algorithm: 'sha256' },
+        hawk: {
+          authId: 'dh37fgj492je',
+          authKey: 'werxhqb98rpaxn39848xrunpaw3489ru',
+          algorithm: 'sha256',
+        },
       },
       timeout: 3000,
     })
@@ -511,6 +574,23 @@ describe('http.engine auth — hawk', () => {
     expect(f.mac).toBe(expectedMac)
     // sha1 MAC is 20 bytes → 28 base64 chars.
     expect(Buffer.from(f.mac, 'base64').length).toBe(20)
+  })
+
+  // issue #48 (same class): a per-request Authorization header wins over a
+  // computed Hawk header.
+  it('does not clobber an explicit Authorization header set in Headers tab', async () => {
+    reset()
+    await executeHttpRequest({
+      method: 'GET',
+      url: baseUrl('/hawk'),
+      headers: [{ id: '1', key: 'Authorization', value: 'Bearer request-own', enabled: true }],
+      auth: {
+        type: 'hawk',
+        hawk: { authId: 'idy', authKey: 'keyz', algorithm: 'sha1' },
+      },
+      timeout: 3000,
+    })
+    expect(captured?.headers.authorization).toBe('Bearer request-own')
   })
 })
 

--- a/website/src/content/docs/changelog.md
+++ b/website/src/content/docs/changelog.md
@@ -10,6 +10,23 @@ source of truth for release descriptions — the CI release job mirrors
 each entry into the matching [GitHub Release](https://github.com/apinizer/testnizer/releases),
 where signed installers and SHA-256 checksums are attached.
 
+## v1.4.35
+
+**The Collection Runner now sends each request's own Authorization header
+instead of an inherited management token.**
+
+In a multi-step run, an early setup step often obtains a management access token
+(e.g. `Bearer apnz_…`) that is inherited as the collection / folder auth. Later
+requests that declare their **own** Authorization header — a gateway introspect
+carrying `Basic client_id:secret`, or a regenerate carrying a freshly minted
+`Bearer eyJ…` JWT — used to have that header silently overwritten by the
+inherited token, so the server saw the wrong credential and answered *Missing
+Parameter: client_id* or *Invalid JWT serialization*. The request's own
+Authorization header now wins, matching Insomnia / Postman. Only the Basic-auth
+path guarded against this before; the guard now covers Bearer, OAuth 2.0,
+API-key, and Hawk auth as well. It's a single fix in the HTTP engine, so the
+Send button and the Runner behave identically (issue #48).
+
 ## v1.4.34
 
 **Switching sidebar pages no longer disturbs your open tabs, tool inputs stick

--- a/website/src/content/docs/tr/changelog.md
+++ b/website/src/content/docs/tr/changelog.md
@@ -11,6 +11,24 @@ girdiyi karşılığı olan [GitHub Release](https://github.com/apinizer/testniz
 sayfasına aynalar; imzalı yükleyiciler ve SHA-256 sağlama toplamları
 orada eklenir.
 
+## v1.4.35
+
+**Collection Runner artık her isteğin kendi Authorization header'ını, miras
+alınan bir yönetim token'ı yerine gönderiyor.**
+
+Çok adımlı bir koşuda, erken bir kurulum adımı çoğu zaman bir yönetim erişim
+token'ı (ör. `Bearer apnz_…`) alır ve bu, koleksiyon / klasör auth'u olarak miras
+alınır. Kendi **Authorization header'ını** tanımlayan sonraki istekler — `Basic
+client_id:secret` taşıyan bir gateway introspect ya da yeni üretilmiş bir `Bearer
+eyJ…` JWT taşıyan bir regenerate — bu header'ın miras alınan token tarafından
+sessizce ezilmesine maruz kalıyordu; sunucu yanlış kimlik bilgisini görüyor ve
+*Missing Parameter: client_id* veya *Invalid JWT serialization* yanıtını
+veriyordu. Artık isteğin kendi Authorization header'ı kazanıyor — Insomnia /
+Postman ile aynı davranış. Bundan önce yalnızca Basic-auth yolu buna karşı
+korumalıydı; koruma artık Bearer, OAuth 2.0, API-key ve Hawk auth'u da kapsıyor.
+Bu, HTTP engine'de tek bir düzeltme olduğu için Send butonu ve Runner birebir aynı
+davranıyor (issue #48).
+
 ## v1.4.34
 
 **Sidebar sayfaları arasında geçiş artık açık sekmelerinizi bozmuyor, araç

--- a/website/src/lib/latest-release.ts
+++ b/website/src/lib/latest-release.ts
@@ -46,8 +46,8 @@ export interface RepoStats {
 }
 
 const FALLBACK: LatestRelease = {
-  tag: 'v1.4.34',
-  version: '1.4.34',
+  tag: 'v1.4.35',
+  version: '1.4.35',
   htmlUrl: 'https://github.com/apinizer/testnizer/releases/latest',
   publishedAt: null,
   assets: [],


### PR DESCRIPTION
## Summary

Fixes **issue #48** — the Collection Runner sent an inherited management Bearer
token instead of a request's own Authorization header.

In a multi-step run, a setup step's management access token (`Bearer apnz_…`) is
resolved as the inherited collection/folder auth. Gateway requests that declare
their **own** Authorization header — `Basic client_id:secret` for an OAuth
introspect, or a freshly minted `Bearer eyJ…` JWT for a regenerate — had that
header silently clobbered by the inherited token, so the server answered
`400 Missing Parameter: client_id` / `401 Invalid JWT serialization`.

## Root cause

`applyAuth()` in `src/main/protocols/http.engine.ts` is the single place auth
headers are built (both Send and Run go through it). Only the **basic** branch
guarded against overwriting an explicit user-set `Authorization` header (since
v1.4.4). `bearer`, `oauth2`, `api-key` (header), and `hawk` wrote the header
unconditionally, so an inherited Bearer overwrote the request's own header.

## Fix

Factor the guard into a shared `hasExplicitHeader(config, name)` helper and apply
it to every Authorization-setting auth type. A per-request Authorization header
now wins over any inherited/collection/environment auth — matching
Insomnia/Postman. One engine-level fix covers Send and Run at once.

## Tests

5 new cases in `tests/main/http-engine-auth.test.ts` drive the real engine and
assert the request's own header reaches the wire (each **fails before**, passes
after):

- bearer — the exact `apnz_` management-token scenario
- bearer — a lower-cased `Basic` header wins over an inherited Bearer
- oauth2 — resolved access token does not clobber an explicit header
- api-key — a same-named header the request declares wins
- hawk — computed header defers to an explicit one

Full suite green: 2000 passed / 24 skipped. `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
