### PR TITLE
feat: Apinizer test-collection interop (x-apinizer) + v1.4.36

### DIFF
--- a/docs/release-notes/v1.4.36.md
+++ b/docs/release-notes/v1.4.36.md
@@ -1,0 +1,37 @@
+## v1.4.36
+
+**Import Apinizer test collections — and export back to them — at full
+fidelity.**
+
+- **New "Apinizer" import source:** the Import dialog (and the sidebar Import
+  menu) now has a first-party **Apinizer** option next to Postman. Apinizer test
+  collections are Postman v2.1 collections that carry an `x-apinizer` extension,
+  so the same importer handles both — the dedicated card is there so importing
+  from Apinizer is a named, obvious path.
+- **Full-fidelity import (`x-apinizer`):** when the extension is present,
+  Testnizer reads it as the primary source of truth instead of re-parsing test
+  scripts. You get native assertions for all four carryable kinds — status code,
+  body, JSONPath, and XPath — plus the raw-body sub-type (JSON / XML / HTML) that
+  a plain Postman body would otherwise collapse to text, plus the request
+  timeout. A collection *without* the extension still imports exactly as before.
+- **Export writes `x-apinizer` back:** exporting a project or a test suite to
+  Postman now embeds `x-apinizer` on each request that has carryable test
+  fidelity, so Apinizer can read your assertions back losslessly. Testnizer-only
+  assertion types (header checks, response-time/size, ranges, free scripts) stay
+  in Testnizer's own channel and are simply left out of the extension. Requests
+  with no assertions export as clean, plain Postman — no extra keys.
+- **Correct Apinizer test/api type on export:** the exported `testType` /
+  `apiType` are derived from the request protocol (REST→RESOURCE, SOAP→WSDL,
+  gRPC/WebSocket/AI→their API type) rather than carried over, because a test
+  imported into Testnizer is standalone — it has no Apinizer proxy binding, so a
+  stale `PROXY` type would be wrong to send back.
+
+**Non-breaking:** the whole feature is additive — existing Postman / Insomnia /
+OpenAPI import and export flows are unchanged; `x-apinizer` only engages when
+it's actually present.
+
+**Tests:** a new interop suite covers the four assertion kinds on import,
+raw-body-type recovery, timeout, the schema-version gate, the export downgrade
+of unmappable types, suite-column export, the derived test/api types, and a
+full import→export round-trip — plus import-dialog cases proving an Apinizer
+collection is accepted under the new card.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testnizer",
   "productName": "Testnizer",
-  "version": "1.4.35",
+  "version": "1.4.36",
   "description": "Testnizer — Cross-platform desktop API testing application",
   "main": "./out/main/index.js",
   "homepage": "https://www.testnizer.com",

--- a/src/main/ipc/import-export.handler.ts
+++ b/src/main/ipc/import-export.handler.ts
@@ -1375,6 +1375,10 @@ interface PostmanItem {
   /** Folder-level auth — inherited by descendant requests that don't set
    *  their own (Postman item-groups can carry an `auth` block). */
   auth?: PostmanAuth
+  /** Apinizer test-interop extension. Postman v2.1 preserves unknown custom
+   *  keys, so Apinizer's extra fidelity (structured assertions, raw-body
+   *  sub-type, timeout) rides here and round-trips through Testnizer. */
+  'x-apinizer'?: XApinizerExtension
 }
 
 interface PostmanEvent {
@@ -1549,6 +1553,249 @@ function readAuthField(src: PostmanAuth[keyof PostmanAuth] | undefined, key: str
 
 function genKvId(): string {
   return Math.random().toString(36).slice(2, 10)
+}
+
+// ─── x-apinizer extension (Apinizer ↔ Testnizer test interop, contract v1.0) ──
+//
+// Postman v2.1 preserves unknown custom keys, so Apinizer ships its extra test
+// fidelity under an `x-apinizer` key on each item — and reads it back on the
+// return trip. We READ it on import (additive; a collection without the key
+// still imports as plain Postman) and WRITE it on export so the round-trip
+// through Testnizer is lossless for the four assertion kinds Apinizer can carry
+// (STATUS_CODE / BODY / JSONPATH / XPATH). Testnizer-only assertion types stay
+// in Testnizer's own `assertions` JSON and are simply omitted from the
+// extension (contract §4.1). See md_files/testnizer-interop/00-shared-contract.md.
+
+type XApinizerKind = 'STATUS_CODE' | 'BODY' | 'JSONPATH' | 'XPATH'
+
+interface XApinizerAssertion {
+  kind: XApinizerKind
+  expected?: string | number
+  /** JSONPath / XPath expression — only present for *PATH kinds. */
+  path?: string
+}
+
+interface XApinizerExtension {
+  schemaVersion?: string
+  source?: string
+  /** Raw-body sub-type Postman can't carry natively: JSON / XML / TEXT / HTML. */
+  bodyRowType?: string
+  timeoutSeconds?: number
+  testType?: string
+  apiType?: string
+  assertions?: XApinizerAssertion[]
+}
+
+/** Minimal Testnizer assertion shape produced/consumed here — mirrors
+ *  TestAssertion in renderer types. Kept local to avoid importing renderer
+ *  code into the main process (same pattern as runner.handler.ts). */
+interface TestAssertionLike {
+  id: string
+  name: string
+  type: string
+  enabled: boolean
+  expected?: string | number
+  jsonPath?: string
+  xPath?: string
+}
+
+/** Major version of the x-apinizer schema this build understands. A collection
+ *  tagged with a newer MAJOR falls back to plain Postman (graceful). */
+const X_APINIZER_SCHEMA_MAJOR = 1
+
+/** True when we understand this item's x-apinizer payload. An omitted version is
+ *  treated as current; a mismatched MAJOR means ignore-and-fall-back. */
+function xApinizerVersionOk(ext: XApinizerExtension | undefined): boolean {
+  if (!ext) return false
+  const v = ext.schemaVersion
+  if (!v) return true
+  const major = parseInt(String(v).split('.')[0] ?? '', 10)
+  return Number.isFinite(major) && major === X_APINIZER_SCHEMA_MAJOR
+}
+
+/** x-apinizer body row-type (JSON/XML/TEXT/HTML) → Testnizer raw sub-type.
+ *  Postman keeps the language in `options.raw.language`, but Apinizer's RAW
+ *  export often omits it, collapsing every raw body to plain text — this
+ *  recovers the json/xml/html distinction. */
+function apinizerRowTypeToBodyType(rowType: string | undefined): string | undefined {
+  switch ((rowType ?? '').toUpperCase()) {
+    case 'JSON':
+      return 'json'
+    case 'XML':
+      return 'xml'
+    case 'HTML':
+      return 'html'
+    case 'TEXT':
+      return 'text'
+    default:
+      return undefined
+  }
+}
+
+/** Only refine the raw text family — never re-type form-data / urlencoded /
+ *  binary / none, which have no row-type. */
+function isRawFamilyBodyType(t: string | undefined): boolean {
+  return t === 'text' || t === 'json' || t === 'xml' || t === 'html' || t === 'raw'
+}
+
+function looksLikeJson(s: string): boolean {
+  const t = s.trim()
+  if (!t || !/^[[{]/.test(t)) return false
+  try {
+    JSON.parse(t)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function truncateLabel(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n) + '…' : s
+}
+
+/** x-apinizer.assertions[] → Testnizer TestAssertion[]. Unknown kinds are
+ *  skipped with a warning (no silent drop). This is the *primary* assertion
+ *  source when present — more reliable than parsing the Postman test script. */
+function xApinizerAssertionsToUi(
+  assertions: XApinizerAssertion[] | undefined,
+  warnings: string[],
+): TestAssertionLike[] {
+  if (!Array.isArray(assertions)) return []
+  const out: TestAssertionLike[] = []
+  for (const a of assertions) {
+    const expected = a.expected
+    switch (a.kind) {
+      case 'STATUS_CODE':
+        out.push({
+          id: genKvId(),
+          name: `Status code is ${expected ?? ''}`.trim(),
+          type: 'status_equals',
+          enabled: true,
+          expected,
+        })
+        break
+      case 'BODY': {
+        // Apinizer's BODY assertion is a full-body match. Prefer a JSON deep
+        // equal when the expected value parses as JSON; otherwise fall back to
+        // a substring `contains` (best-effort, per contract §4).
+        const raw = typeof expected === 'string' ? expected : JSON.stringify(expected ?? '')
+        const isJson = looksLikeJson(raw)
+        out.push({
+          id: genKvId(),
+          name: isJson ? 'Body equals JSON' : `Body contains "${truncateLabel(raw, 32)}"`,
+          type: isJson ? 'body_equals_json' : 'body_contains',
+          enabled: true,
+          expected: raw,
+        })
+        break
+      }
+      case 'JSONPATH':
+        out.push({
+          id: genKvId(),
+          name: `JSONPath ${a.path ?? '$'} equals ${expected ?? ''}`.trim(),
+          type: 'body_jsonpath',
+          enabled: true,
+          jsonPath: a.path ?? '$',
+          expected,
+        })
+        break
+      case 'XPATH':
+        out.push({
+          id: genKvId(),
+          name: `XPath ${a.path ?? ''} equals ${expected ?? ''}`.trim(),
+          type: 'body_xpath',
+          enabled: true,
+          xPath: a.path ?? '',
+          expected,
+        })
+        break
+      default:
+        warnings.push(
+          `Skipped unknown x-apinizer assertion kind "${String((a as XApinizerAssertion).kind)}"`,
+        )
+    }
+  }
+  return out
+}
+
+/** Testnizer body sub-type → x-apinizer bodyRowType. Only the raw family maps. */
+function bodyTypeToApinizerRowType(bodyType: string | undefined): string | undefined {
+  switch ((bodyType ?? '').toLowerCase()) {
+    case 'json':
+      return 'JSON'
+    case 'xml':
+      return 'XML'
+    case 'html':
+      return 'HTML'
+    case 'text':
+    case 'raw':
+      return 'TEXT'
+    default:
+      return undefined
+  }
+}
+
+/** Testnizer TestAssertion[] → x-apinizer.assertions[], keeping only the four
+ *  kinds Apinizer's boolean-flag model can carry. Unmappable types
+ *  (status_in_range, header_*, response_time/size_under, pm_script) are dropped
+ *  from the extension — they stay in Testnizer's own `assertions` JSON for a
+ *  Testnizer→Testnizer round-trip (contract §4.1). */
+function assertionsToXApinizer(assertions: TestAssertionLike[]): XApinizerAssertion[] {
+  const out: XApinizerAssertion[] = []
+  for (const a of assertions) {
+    switch (a.type) {
+      case 'status_equals':
+        out.push({ kind: 'STATUS_CODE', expected: a.expected })
+        break
+      case 'body_equals_json':
+      case 'body_contains':
+        out.push({ kind: 'BODY', expected: a.expected })
+        break
+      case 'body_jsonpath':
+        out.push({ kind: 'JSONPATH', path: a.jsonPath ?? '$', expected: a.expected })
+        break
+      case 'body_xpath':
+        out.push({ kind: 'XPATH', path: a.xPath ?? '', expected: a.expected })
+        break
+      default:
+        // Unmappable — intentionally skipped (kept in Testnizer's own channel).
+        break
+    }
+  }
+  return out
+}
+
+/**
+ * Derive Apinizer's `apiType` (EnumApiType) + `testType`
+ * (EnumApiTestConsoleTestType) from the Testnizer protocol.
+ *
+ * We DERIVE rather than preserve an original value because a test imported into
+ * Testnizer loses its Apinizer proxy binding (contract §0/§5.6 — apiProxyID etc.
+ * are null), so it is a standalone test regardless of where it came from — the
+ * original `PROXY` testType would be wrong to carry back. Deriving gives both
+ * natively-authored and round-tripped tests a correct, proxy-free value:
+ *   - apiType picks the closest EnumApiType (REST/SOAP/GRPC/WEBSOCKET/AI).
+ *   - testType picks a standalone test-console kind: RESOURCE for the REST
+ *     family (isRest), WSDL for SOAP (isSoap), API (neutral) for the rest.
+ */
+function protocolToApinizerTypes(protocol: string | undefined): {
+  apiType: string
+  testType: string
+} {
+  switch ((protocol ?? 'http').toLowerCase()) {
+    case 'soap':
+      return { apiType: 'SOAP', testType: 'WSDL' }
+    case 'grpc':
+      return { apiType: 'GRPC', testType: 'API' }
+    case 'websocket':
+    case 'socketio':
+      return { apiType: 'WEBSOCKET', testType: 'API' }
+    case 'ai':
+      return { apiType: 'AI', testType: 'API' }
+    default:
+      // http / graphql / sse / mcp — all HTTP/REST-family.
+      return { apiType: 'REST', testType: 'RESOURCE' }
+  }
 }
 
 /** Reconstruct a full URL from a Postman url object or string. Preserves
@@ -1979,6 +2226,32 @@ export async function importPostman(
       if (preScript) requestSchema.preScript = preScript
       if (postScript) requestSchema.postScript = postScript
 
+      // ── Apinizer interop: fold x-apinizer fidelity back in (additive) ──
+      // Structured assertions from the extension are the primary source (more
+      // reliable than re-parsing the Postman test script); the raw-body
+      // sub-type and timeout that Postman can't carry are recovered too. Absent
+      // or unknown-version extensions leave the plain-Postman import untouched.
+      const xa = item['x-apinizer']
+      if (xa && xApinizerVersionOk(xa)) {
+        const xaAssertions = xApinizerAssertionsToUi(xa.assertions, warnings)
+        if (xaAssertions.length > 0) requestSchema.assertions = xaAssertions
+        const refinedBodyType = apinizerRowTypeToBodyType(xa.bodyRowType)
+        if (refinedBodyType && isRawFamilyBodyType(body.type)) {
+          // `body` is the same object stored under requestSchema.body, so
+          // mutating it here updates the persisted schema.
+          body.type = refinedBodyType
+        }
+        if (typeof xa.timeoutSeconds === 'number') {
+          requestSchema.timeoutSeconds = xa.timeoutSeconds
+        }
+      } else if (xa) {
+        warnings.push(
+          `Ignored x-apinizer extension with unsupported schemaVersion "${
+            xa.schemaVersion ?? '(none)'
+          }" on "${item.name ?? '(unnamed)'}" — imported as plain Postman.`,
+        )
+      }
+
       const endpointId = randomUUID()
       db.prepare(
         `INSERT INTO endpoints (id, project_id, folder_id, name, description, protocol, method, path, status, request_schema, response_schemas, sort_order, created_at, updated_at)
@@ -2148,6 +2421,15 @@ interface UiRequestSchema {
   auth?: Record<string, unknown>
   preScript?: string
   postScript?: string
+  /**
+   * Test assertions. Endpoint rows keep their assertions INSIDE request_schema
+   * (no separate column — see save-active-request.ts / open-endpoint-tab.ts);
+   * the Apinizer interop reads/writes them here for the Postman x-apinizer
+   * round-trip.
+   */
+  assertions?: TestAssertionLike[]
+  /** Request timeout in seconds — carried via x-apinizer.timeoutSeconds. */
+  timeoutSeconds?: number
   /**
    * OpenAPI round-trip metadata. Populated by `importOpenApi`; consumed by
    * `exportProjectAsOpenApi` to preserve tags / operationId / security /
@@ -2358,6 +2640,13 @@ interface ExportEndpointRow {
   name: string
   description: string | null
   request_schema: string | null
+  /** Suite items store assertions in their own column (not in request_schema);
+   *  project endpoints keep them inside request_schema. Threaded here so the
+   *  x-apinizer export reads whichever the source uses. */
+  assertions?: string | null
+  /** Source protocol (http/soap/grpc/…) — drives the derived x-apinizer
+   *  apiType/testType. Optional: the Insomnia export path leaves it undefined. */
+  protocol?: string | null
 }
 
 type PostmanScriptEvent = {
@@ -2493,6 +2782,42 @@ function buildPostmanCollection(
       ;(item as PostmanItem & { event?: PostmanScriptEvent[] }).event = events
     }
 
+    // ── Apinizer interop: attach x-apinizer when there's carryable fidelity ──
+    // Assertions live either on a threaded column (suite items) or inside
+    // request_schema (project endpoints) — prefer the column, fall back to the
+    // schema. We only attach the extension when there's something Apinizer can
+    // actually carry (mapped assertions or a timeout) so pure Postman exports
+    // stay clean.
+    let itemAssertions: TestAssertionLike[] = []
+    if (ep.assertions) {
+      try {
+        const parsed = JSON.parse(ep.assertions) as TestAssertionLike[]
+        if (Array.isArray(parsed)) itemAssertions = parsed
+      } catch {
+        /* malformed assertions column — skip */
+      }
+    }
+    if (itemAssertions.length === 0 && Array.isArray(schema.assertions)) {
+      itemAssertions = schema.assertions
+    }
+    const xaAssertions = assertionsToXApinizer(itemAssertions)
+    const timeoutSeconds =
+      typeof schema.timeoutSeconds === 'number' ? schema.timeoutSeconds : undefined
+    if (xaAssertions.length > 0 || timeoutSeconds !== undefined) {
+      const { apiType, testType } = protocolToApinizerTypes(ep.protocol ?? undefined)
+      const ext: XApinizerExtension = {
+        schemaVersion: '1.0',
+        source: 'testnizer',
+        testType,
+        apiType,
+      }
+      const rowType = bodyTypeToApinizerRowType(schema.body?.type)
+      if (rowType) ext.bodyRowType = rowType
+      if (timeoutSeconds !== undefined) ext.timeoutSeconds = timeoutSeconds
+      if (xaAssertions.length > 0) ext.assertions = xaAssertions
+      ;(item as PostmanItem)['x-apinizer'] = ext
+    }
+
     if (ep.folder_id && folderMap.has(ep.folder_id)) {
       folderMap.get(ep.folder_id)!.item!.push(item)
     } else {
@@ -2568,6 +2893,8 @@ export function exportSuiteAsPostman(suiteId: string): string {
     url: string | null
     name: string
     request_schema: string | null
+    assertions: string | null
+    protocol: string | null
   }>
   const endpoints: ExportEndpointRow[] = items.map((it) => ({
     id: it.id,
@@ -2577,6 +2904,10 @@ export function exportSuiteAsPostman(suiteId: string): string {
     name: it.name,
     description: null,
     request_schema: it.request_schema,
+    // Suite items carry assertions in their own column → thread so the
+    // x-apinizer export can emit them.
+    assertions: it.assertions,
+    protocol: it.protocol,
   }))
 
   const collection = buildPostmanCollection(

--- a/src/renderer/components/modals/ImportModal.tsx
+++ b/src/renderer/components/modals/ImportModal.tsx
@@ -40,6 +40,17 @@ const IMPORT_FORMATS: ImportFormat[] = [
     color: '#5b52d4',
     mono: true,
   },
+  // Apinizer test collections are Postman v2.1 + `x-apinizer` \u2014 the same
+  // importer handles both (importPostman reads the extension when present).
+  // A dedicated branded card surfaces the first-party interop path.
+  {
+    id: 'apinizer',
+    name: 'Apinizer',
+    icon: 'AP',
+    bg: '#e6f7ee',
+    color: '#1b9a59',
+    mono: true,
+  },
   { id: 'openapi', name: 'OpenAPI/Swagger', icon: '\uD83C\uDF3F', bg: '#e8f9f1', color: '#1a7a4a' },
   { id: 'postman', name: 'Postman', icon: '\uD83D\uDFE0', bg: '#fff0ec', color: '#f25c00' },
   { id: 'insomnia', name: 'Insomnia', icon: '\uD83D\uDFE3', bg: '#faf0ff', color: '#7c4dff' },
@@ -54,6 +65,7 @@ const IMPORT_FORMATS: ImportFormat[] = [
 const URL_IMPORTABLE = ['openapi', 'wsdl', 'raml']
 const FILE_IMPORTABLE = [
   'native',
+  'apinizer',
   'openapi',
   'postman',
   'insomnia',
@@ -67,7 +79,16 @@ const FILE_IMPORTABLE = [
 // Formats whose spec is plain text we can read straight from the clipboard and
 // feed into the same string-based import pipeline (issue #28). cURL has its own
 // paste textarea; proto/WSDL need a file path or a live URL, so both opt out.
-const CLIPBOARD_IMPORTABLE = ['native', 'openapi', 'postman', 'insomnia', 'har', 'raml', 'soapui']
+const CLIPBOARD_IMPORTABLE = [
+  'native',
+  'apinizer',
+  'openapi',
+  'postman',
+  'insomnia',
+  'har',
+  'raml',
+  'soapui',
+]
 
 function FormatIcon({ fmt }: { fmt: ImportFormat }) {
   if (fmt.mono) {
@@ -484,7 +505,10 @@ export default function ImportModal() {
           folderId,
           sourceUrl: pendingSourceUrl || undefined,
         })) as typeof importResult
-      } else if (fmtId === 'postman') {
+      } else if (fmtId === 'postman' || fmtId === 'apinizer') {
+        // Apinizer collections are Postman v2.1 with an `x-apinizer` extension;
+        // importPostman reads that extension when present, so a single code
+        // path serves both cards — the separate card is UX/branding only.
         importResult = (await window.api?.importExport?.importPostman({
           projectId: pid,
           content: pendingFileContent || '',
@@ -593,10 +617,10 @@ export default function ImportModal() {
       const importerOk = importResult?.data?.success !== false
       if (ipcOk && importerOk) {
         await refreshTree()
-        // Postman/Insomnia imports may create a project-scoped environment for
-        // collection variables. Refresh the env store so the new env shows up
-        // in the selector without requiring an app reload.
-        if (fmtId === 'postman' || fmtId === 'insomnia') {
+        // Postman/Apinizer/Insomnia imports may create a project-scoped
+        // environment for collection variables. Refresh the env store so the
+        // new env shows up in the selector without requiring an app reload.
+        if (fmtId === 'postman' || fmtId === 'apinizer' || fmtId === 'insomnia') {
           await useEnvironmentStore.getState().fetchEnvironments()
         }
         toast.success(t('toast.imported'))

--- a/src/renderer/components/sidebar/ImportDropdown.tsx
+++ b/src/renderer/components/sidebar/ImportDropdown.tsx
@@ -45,6 +45,7 @@ const CATEGORIES: ImportFormatCategory[] = [
   {
     titleKey: 'importDropdown.section.collections',
     options: [
+      { id: 'apinizer', name: 'Apinizer' },
       { id: 'postman', name: 'Postman' },
       { id: 'insomnia', name: 'Insomnia' },
       { id: 'har', name: 'HAR' },

--- a/src/renderer/lib/import-format-detect.ts
+++ b/src/renderer/lib/import-format-detect.ts
@@ -138,7 +138,10 @@ export function checkTypeMismatch(
     proto: ['proto'],
     raml: ['raml'],
     openapi: ['openapi'],
-    postman: ['postman'],
+    // Apinizer test collections ARE Postman v2.1 (+ x-apinizer), so they
+    // detect as `postman`; accept them under either the Postman or the
+    // Apinizer import card (both route to importPostman).
+    postman: ['postman', 'apinizer'],
     insomnia: ['insomnia'],
     curl: ['curl'],
     native: ['native'],
@@ -148,7 +151,7 @@ export function checkTypeMismatch(
     // also added here so a Testnizer export that misses the strict tagged
     // detection still routes through the native importer (which carries
     // its own structural validator).
-    json: ['openapi', 'postman', 'insomnia', 'raml', 'native'],
+    json: ['openapi', 'postman', 'apinizer', 'insomnia', 'raml', 'native'],
     xml: ['wsdl', 'soapui'],
   }
 
@@ -159,6 +162,7 @@ export function checkTypeMismatch(
   const human: Record<string, string> = {
     openapi: 'OpenAPI/Swagger',
     postman: 'Postman',
+    apinizer: 'Apinizer',
     insomnia: 'Insomnia',
     curl: 'cURL',
     raml: 'RAML',

--- a/tests/main/import-export-apinizer.test.ts
+++ b/tests/main/import-export-apinizer.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Apinizer ↔ Testnizer test interop — `x-apinizer` extension read/write.
+ *
+ * Verifies the fidelity layer described in
+ * md_files/testnizer-interop/{00-shared-contract,testnizer-side-plan}.md:
+ *
+ *  - IMPORT (`importPostman`): an Apinizer collection carrying `x-apinizer`
+ *    yields native Testnizer assertions (4 kinds) + recovered raw-body sub-type
+ *    + timeout. A collection WITHOUT the key still imports as plain Postman.
+ *  - EXPORT (`buildPostmanCollection` via project/suite export): Testnizer
+ *    assertions round-trip into `x-apinizer.assertions[]`; Testnizer-only
+ *    assertion types are dropped from the extension (kept in Testnizer's own
+ *    channel). Pure requests (no assertions) get no `x-apinizer` at all.
+ *  - ROUND-TRIP: Apinizer fixture → import → export preserves the 4 kinds.
+ *
+ * Driven against a real schema-loaded better-sqlite3 instance (same harness as
+ * export-suite.test.ts) so every production migration/column is present.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
+import { mkdtempSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'testnizer-apinizer-'))
+
+vi.mock('electron', () => ({
+  app: { getPath: (_: string): string => tmpDir },
+  ipcMain: { handle: (): void => {} },
+  dialog: {},
+  safeStorage: { isEncryptionAvailable: (): boolean => false },
+}))
+
+import { initDatabase, getDb } from '../../src/main/db/database'
+import {
+  importPostman,
+  exportAsPostman,
+  exportSuiteAsPostman,
+} from '../../src/main/ipc/import-export.handler'
+
+// ─── Postman v2.1 shapes (loose — tests only touch a subset) ─────────────
+interface PmAssertion {
+  kind: string
+  expected?: string | number
+  path?: string
+}
+interface PmItem {
+  name: string
+  request?: Record<string, unknown>
+  item?: PmItem[]
+  'x-apinizer'?: {
+    schemaVersion?: string
+    source?: string
+    bodyRowType?: string
+    timeoutSeconds?: number
+    testType?: string
+    apiType?: string
+    assertions?: PmAssertion[]
+  }
+}
+interface PmCollection {
+  info: { name: string; schema: string }
+  item: PmItem[]
+}
+
+interface UiAssertion {
+  type: string
+  expected?: string | number
+  jsonPath?: string
+  xPath?: string
+  name: string
+  enabled: boolean
+}
+interface UiSchema {
+  body?: { type?: string; content?: string }
+  assertions?: UiAssertion[]
+  timeoutSeconds?: number
+}
+
+let projectId: string
+let workspaceId: string
+
+beforeAll(() => {
+  initDatabase()
+})
+
+beforeEach(() => {
+  const db = getDb()
+  projectId = randomUUID()
+  workspaceId = (db.prepare('SELECT id FROM workspaces LIMIT 1').get() as { id: string }).id
+  const now = Date.now()
+  db.prepare(
+    `INSERT INTO projects (id, workspace_id, name, description, type, sort_order, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'http', 0, ?, ?)`,
+  ).run(projectId, workspaceId, 'ApinizerPrj', 'interop project', now, now)
+})
+
+/** Read back every endpoint imported into the project, newest sort first. */
+function endpointSchemas(): Array<{ name: string; method: string; schema: UiSchema }> {
+  const db = getDb()
+  const rows = db
+    .prepare(
+      'SELECT name, method, request_schema FROM endpoints WHERE project_id = ? ORDER BY sort_order',
+    )
+    .all(projectId) as Array<{ name: string; method: string; request_schema: string }>
+  return rows.map((r) => ({
+    name: r.name,
+    method: r.method,
+    schema: JSON.parse(r.request_schema) as UiSchema,
+  }))
+}
+
+/** Build a single-item Apinizer collection with an item-level x-apinizer. */
+function apinizerCollection(item: PmItem): string {
+  return JSON.stringify({
+    info: {
+      name: 'Apinizer Export',
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      'x-apinizer': { schemaVersion: '1.0', kind: 'test-collection' },
+    },
+    item: [item],
+  })
+}
+
+// ─── IMPORT: x-apinizer → native assertions ──────────────────────────────
+
+describe('importPostman — x-apinizer read (Apinizer → Testnizer)', () => {
+  it('maps all four assertion kinds to native TestAssertion types', async () => {
+    const content = apinizerCollection({
+      name: 'Create User',
+      request: {
+        method: 'POST',
+        url: 'https://api.example.com/users',
+        body: { mode: 'raw', raw: '{"name":"a"}' }, // no options.raw.language
+      },
+      'x-apinizer': {
+        schemaVersion: '1.0',
+        source: 'apinizer',
+        bodyRowType: 'JSON',
+        timeoutSeconds: 45,
+        assertions: [
+          { kind: 'STATUS_CODE', expected: 201 },
+          { kind: 'BODY', expected: '{"ok":true}' },
+          { kind: 'JSONPATH', path: '$.user.id', expected: '123' },
+          { kind: 'XPATH', path: '//id', expected: '5' },
+        ],
+      },
+    })
+
+    const res = await importPostman(projectId, content)
+    expect(res.success).toBe(true)
+
+    const [ep] = endpointSchemas()
+    const a = ep.schema.assertions ?? []
+    expect(a.map((x) => x.type)).toEqual([
+      'status_equals',
+      'body_equals_json',
+      'body_jsonpath',
+      'body_xpath',
+    ])
+    expect(a[0]).toMatchObject({ type: 'status_equals', expected: 201, enabled: true })
+    expect(a[1]).toMatchObject({ type: 'body_equals_json', expected: '{"ok":true}' })
+    expect(a[2]).toMatchObject({ type: 'body_jsonpath', jsonPath: '$.user.id', expected: '123' })
+    expect(a[3]).toMatchObject({ type: 'body_xpath', xPath: '//id', expected: '5' })
+    // every synthesised assertion carries a human-readable name
+    expect(a.every((x) => typeof x.name === 'string' && x.name.length > 0)).toBe(true)
+  })
+
+  it('recovers the raw-body sub-type from bodyRowType when Postman omits the language', async () => {
+    const content = apinizerCollection({
+      name: 'SOAP call',
+      request: {
+        method: 'POST',
+        url: 'https://api.example.com/soap',
+        body: { mode: 'raw', raw: '<x/>' }, // Postman would default to text
+      },
+      'x-apinizer': { schemaVersion: '1.0', bodyRowType: 'XML' },
+    })
+
+    await importPostman(projectId, content)
+    const [ep] = endpointSchemas()
+    expect(ep.schema.body?.type).toBe('xml')
+  })
+
+  it('maps a non-JSON BODY assertion to body_contains (best-effort)', async () => {
+    const content = apinizerCollection({
+      name: 'Text body',
+      request: { method: 'GET', url: 'https://api.example.com/ping' },
+      'x-apinizer': {
+        schemaVersion: '1.0',
+        assertions: [{ kind: 'BODY', expected: 'pong' }],
+      },
+    })
+
+    await importPostman(projectId, content)
+    const [ep] = endpointSchemas()
+    expect(ep.schema.assertions?.[0]).toMatchObject({ type: 'body_contains', expected: 'pong' })
+  })
+
+  it('carries timeoutSeconds into request_schema', async () => {
+    const content = apinizerCollection({
+      name: 'Slow',
+      request: { method: 'GET', url: 'https://api.example.com/slow' },
+      'x-apinizer': { schemaVersion: '1.0', timeoutSeconds: 30 },
+    })
+    await importPostman(projectId, content)
+    const [ep] = endpointSchemas()
+    expect(ep.schema.timeoutSeconds).toBe(30)
+  })
+
+  it('ignores an unknown MAJOR schemaVersion and falls back to plain Postman (with a warning)', async () => {
+    const content = apinizerCollection({
+      name: 'Future',
+      request: { method: 'GET', url: 'https://api.example.com/f' },
+      'x-apinizer': {
+        schemaVersion: '2.0',
+        assertions: [{ kind: 'STATUS_CODE', expected: 200 }],
+      },
+    })
+    const res = await importPostman(projectId, content)
+    expect(res.success).toBe(true)
+    const [ep] = endpointSchemas()
+    expect(ep.schema.assertions).toBeUndefined()
+    expect((res.warnings ?? []).some((w) => /schemaVersion "2\.0"/.test(w))).toBe(true)
+  })
+
+  it('regression: a pure Postman item (no x-apinizer) imports with no assertions key', async () => {
+    const content = JSON.stringify({
+      info: {
+        name: 'Plain',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      item: [{ name: 'Health', request: { method: 'GET', url: 'https://api.example.com/health' } }],
+    })
+    const res = await importPostman(projectId, content)
+    expect(res.success).toBe(true)
+    const [ep] = endpointSchemas()
+    expect(ep.schema.assertions).toBeUndefined()
+    expect(ep.schema.timeoutSeconds).toBeUndefined()
+  })
+})
+
+// ─── EXPORT: native assertions → x-apinizer ──────────────────────────────
+
+/** Seed one project endpoint whose request_schema carries assertions. */
+function insertEndpoint(schema: Record<string, unknown>): void {
+  const db = getDb()
+  const now = Date.now()
+  db.prepare(
+    `INSERT INTO endpoints (id, project_id, folder_id, name, description, protocol, method, path, status, request_schema, sort_order, created_at, updated_at)
+     VALUES (?, ?, NULL, ?, NULL, 'http', ?, ?, 'developing', ?, 0, ?, ?)`,
+  ).run(
+    randomUUID(),
+    projectId,
+    (schema.name as string) ?? 'EP',
+    (schema.method as string) ?? 'GET',
+    (schema.url as string) ?? '/',
+    JSON.stringify(schema),
+    now,
+    now,
+  )
+}
+
+describe('exportAsPostman — x-apinizer write (Testnizer → Apinizer)', () => {
+  it('emits x-apinizer.assertions for the four carryable kinds and drops the rest', () => {
+    insertEndpoint({
+      name: 'Orders',
+      method: 'POST',
+      url: 'https://api.example.com/orders',
+      body: { type: 'json', content: '{}' },
+      timeoutSeconds: 20,
+      assertions: [
+        { id: '1', name: 's', type: 'status_equals', enabled: true, expected: 200 },
+        {
+          id: '2',
+          name: 'jp',
+          type: 'body_jsonpath',
+          enabled: true,
+          jsonPath: '$.id',
+          expected: '9',
+        },
+        { id: '3', name: 'xp', type: 'body_xpath', enabled: true, xPath: '//id', expected: '3' },
+        { id: '4', name: 'bc', type: 'body_contains', enabled: true, expected: 'ok' },
+        // Testnizer-only — must NOT appear in x-apinizer:
+        {
+          id: '5',
+          name: 'rng',
+          type: 'status_in_range',
+          enabled: true,
+          rangeMin: 200,
+          rangeMax: 299,
+        },
+        { id: '6', name: 'hdr', type: 'header_exists', enabled: true, headerName: 'X-Id' },
+        { id: '7', name: 'rt', type: 'response_time_under', enabled: true, expected: 500 },
+        { id: '8', name: 'sc', type: 'pm_script', enabled: true },
+      ],
+    })
+
+    const col = JSON.parse(exportAsPostman(projectId)) as PmCollection
+    const item = col.item.find((i) => i.name === 'Orders')!
+    const xa = item['x-apinizer']!
+    expect(xa.schemaVersion).toBe('1.0')
+    expect(xa.source).toBe('testnizer')
+    expect(xa.bodyRowType).toBe('JSON')
+    expect(xa.timeoutSeconds).toBe(20)
+    // http endpoint → REST-family test-console kind + api type.
+    expect(xa.testType).toBe('RESOURCE')
+    expect(xa.apiType).toBe('REST')
+    expect(xa.assertions).toEqual([
+      { kind: 'STATUS_CODE', expected: 200 },
+      { kind: 'JSONPATH', path: '$.id', expected: '9' },
+      { kind: 'XPATH', path: '//id', expected: '3' },
+      { kind: 'BODY', expected: 'ok' },
+    ])
+  })
+
+  it('derives WSDL/SOAP testType+apiType for a SOAP protocol endpoint', () => {
+    const db = getDb()
+    const now = Date.now()
+    db.prepare(
+      `INSERT INTO endpoints (id, project_id, folder_id, name, description, protocol, method, path, status, request_schema, sort_order, created_at, updated_at)
+       VALUES (?, ?, NULL, 'Soap', NULL, 'soap', 'POST', ?, 'developing', ?, 0, ?, ?)`,
+    ).run(
+      randomUUID(),
+      projectId,
+      'https://api.example.com/soap',
+      JSON.stringify({
+        url: 'https://api.example.com/soap',
+        body: { type: 'xml', content: '<x/>' },
+        assertions: [{ id: '1', name: 's', type: 'status_equals', enabled: true, expected: 200 }],
+      }),
+      now,
+      now,
+    )
+    const col = JSON.parse(exportAsPostman(projectId)) as PmCollection
+    const xa = col.item.find((i) => i.name === 'Soap')!['x-apinizer']!
+    expect(xa.testType).toBe('WSDL')
+    expect(xa.apiType).toBe('SOAP')
+    expect(xa.bodyRowType).toBe('XML')
+  })
+
+  it('omits x-apinizer entirely for a request with no carryable fidelity', () => {
+    insertEndpoint({
+      name: 'Plain',
+      method: 'GET',
+      url: 'https://api.example.com/plain',
+      body: { type: 'json', content: '{}' },
+    })
+    const col = JSON.parse(exportAsPostman(projectId)) as PmCollection
+    const item = col.item.find((i) => i.name === 'Plain')!
+    expect(item['x-apinizer']).toBeUndefined()
+  })
+})
+
+// ─── EXPORT: suite items (assertions live in their own column) ────────────
+
+describe('exportSuiteAsPostman — x-apinizer from the suite item assertions column', () => {
+  it('reads assertions from test_suite_items.assertions', () => {
+    const db = getDb()
+    const now = Date.now()
+    const suiteId = randomUUID()
+    db.prepare(
+      `INSERT INTO test_suites (id, project_id, name, description, sort_order, created_at, updated_at)
+       VALUES (?, ?, 'S', NULL, 0, ?, ?)`,
+    ).run(suiteId, projectId, now, now)
+    db.prepare(
+      `INSERT INTO test_suite_items (id, suite_id, folder_id, protocol, name, method, url, request_schema, assertions, source_endpoint_id, sort_order, created_at, updated_at)
+       VALUES (?, ?, NULL, 'http', 'Login', 'POST', ?, ?, ?, NULL, 0, ?, ?)`,
+    ).run(
+      randomUUID(),
+      suiteId,
+      'https://api.example.com/login',
+      JSON.stringify({
+        url: 'https://api.example.com/login',
+        body: { type: 'json', content: '{}' },
+      }),
+      JSON.stringify([
+        { id: '1', name: 's', type: 'status_equals', enabled: true, expected: 204 },
+        {
+          id: '2',
+          name: 'jp',
+          type: 'body_jsonpath',
+          enabled: true,
+          jsonPath: '$.token',
+          expected: 'abc',
+        },
+      ]),
+      now,
+      now,
+    )
+
+    const col = JSON.parse(exportSuiteAsPostman(suiteId)) as PmCollection
+    const item = col.item.find((i) => i.name === 'Login')!
+    expect(item['x-apinizer']?.assertions).toEqual([
+      { kind: 'STATUS_CODE', expected: 204 },
+      { kind: 'JSONPATH', path: '$.token', expected: 'abc' },
+    ])
+    // Suite item protocol is threaded → derived types come through too.
+    expect(item['x-apinizer']?.testType).toBe('RESOURCE')
+    expect(item['x-apinizer']?.apiType).toBe('REST')
+  })
+})
+
+// ─── ROUND-TRIP: Apinizer fixture → import → export ──────────────────────
+
+describe('round-trip — x-apinizer survives import then export', () => {
+  it('preserves the four assertion kinds + bodyRowType + timeout', async () => {
+    const content = apinizerCollection({
+      name: 'Round',
+      request: {
+        method: 'POST',
+        url: 'https://api.example.com/round',
+        body: { mode: 'raw', raw: '{"a":1}' },
+      },
+      'x-apinizer': {
+        schemaVersion: '1.0',
+        source: 'apinizer',
+        bodyRowType: 'JSON',
+        timeoutSeconds: 15,
+        assertions: [
+          { kind: 'STATUS_CODE', expected: 200 },
+          { kind: 'JSONPATH', path: '$.id', expected: '7' },
+          { kind: 'XPATH', path: '//id', expected: '2' },
+          { kind: 'BODY', expected: '{"done":true}' },
+        ],
+      },
+    })
+    await importPostman(projectId, content)
+
+    const col = JSON.parse(exportAsPostman(projectId)) as PmCollection
+    const item = col.item.find((i) => i.name === 'Round')!
+    const xa = item['x-apinizer']!
+    expect(xa.bodyRowType).toBe('JSON')
+    expect(xa.timeoutSeconds).toBe(15)
+    // Re-exported as a standalone (proxy-free) http test → derived types.
+    expect(xa.testType).toBe('RESOURCE')
+    expect(xa.apiType).toBe('REST')
+    // Import maps BODY(json) → body_equals_json → export maps back to BODY.
+    expect(xa.assertions).toEqual([
+      { kind: 'STATUS_CODE', expected: 200 },
+      { kind: 'JSONPATH', path: '$.id', expected: '7' },
+      { kind: 'XPATH', path: '//id', expected: '2' },
+      { kind: 'BODY', expected: '{"done":true}' },
+    ])
+  })
+})

--- a/tests/renderer/import-modal-mismatch.test.ts
+++ b/tests/renderer/import-modal-mismatch.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  detectImportFormat,
-  checkTypeMismatch,
-} from '../../src/renderer/lib/import-format-detect'
+import { detectImportFormat, checkTypeMismatch } from '../../src/renderer/lib/import-format-detect'
 
 describe('detectImportFormat', () => {
   it('detects WSDL from <?xml + <definitions root', () => {
@@ -144,6 +141,27 @@ describe('checkTypeMismatch', () => {
       detected: 'HAR',
       expected: 'OpenAPI/Swagger',
     })
+  })
+
+  it('accepts a Postman-shaped collection under the Apinizer card (same importer)', () => {
+    // Apinizer test collections ARE Postman v2.1 (+ x-apinizer), so they detect
+    // as `postman`. The Apinizer card must not flag that as a mismatch.
+    expect(checkTypeMismatch('apinizer', 'postman')).toBe(null)
+    expect(checkTypeMismatch('apinizer', 'json')).toBe(null)
+    // And a real Apinizer collection (postman schema + x-apinizer) still detects
+    // as postman → accepted under both cards.
+    const apinizerCol = JSON.stringify({
+      info: {
+        name: 'A',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/',
+        'x-apinizer': { schemaVersion: '1.0', kind: 'test-collection' },
+      },
+      item: [],
+    })
+    const detected = detectImportFormat(apinizerCol)
+    expect(detected).toBe('postman')
+    expect(checkTypeMismatch('apinizer', detected)).toBe(null)
+    expect(checkTypeMismatch('postman', detected)).toBe(null)
   })
 })
 

--- a/website/src/content/docs/changelog.md
+++ b/website/src/content/docs/changelog.md
@@ -10,6 +10,26 @@ source of truth for release descriptions — the CI release job mirrors
 each entry into the matching [GitHub Release](https://github.com/apinizer/testnizer/releases),
 where signed installers and SHA-256 checksums are attached.
 
+## v1.4.36
+
+**Import Apinizer test collections — and export back to them — at full fidelity.**
+
+The Import dialog (and the sidebar Import menu) now has a first-party **Apinizer**
+option next to Postman. Apinizer test collections are Postman v2.1 collections
+that carry an `x-apinizer` extension, so the same importer handles both — the
+dedicated card just makes importing from Apinizer a named, obvious path. When the
+extension is present it becomes the primary source of truth: you get native
+assertions for all four carryable kinds (status code, body, JSONPath, XPath),
+the raw-body sub-type (JSON / XML / HTML) a plain Postman body would collapse to
+text, and the request timeout. Exporting a project or test suite to Postman now
+embeds `x-apinizer` back on each request that has carryable fidelity so Apinizer
+reads your assertions losslessly; Testnizer-only assertion types stay in
+Testnizer's own channel, and requests with no assertions export as clean plain
+Postman. The exported `testType` / `apiType` are derived from the request
+protocol (REST→RESOURCE, SOAP→WSDL, …) because a test imported into Testnizer is
+standalone and has no Apinizer proxy binding. The whole feature is additive —
+existing Postman / Insomnia / OpenAPI flows are unchanged.
+
 ## v1.4.35
 
 **The Collection Runner now sends each request's own Authorization header

--- a/website/src/content/docs/tr/changelog.md
+++ b/website/src/content/docs/tr/changelog.md
@@ -11,6 +11,26 @@ girdiyi karşılığı olan [GitHub Release](https://github.com/apinizer/testniz
 sayfasına aynalar; imzalı yükleyiciler ve SHA-256 sağlama toplamları
 orada eklenir.
 
+## v1.4.36
+
+**Apinizer test koleksiyonlarını tam-fidelity içe alın — ve onlara geri dışa aktarın.**
+
+Import diyaloğunda (ve kenar çubuğu Import menüsünde) artık Postman'in yanında
+first-party bir **Apinizer** seçeneği var. Apinizer test koleksiyonları,
+`x-apinizer` uzantısı taşıyan Postman v2.1 koleksiyonlarıdır; bu yüzden ikisini de
+aynı içe aktarıcı işler — ayrı kart, Apinizer'dan içe almayı adı konmuş, belirgin
+bir yol yapar. Uzantı mevcutsa birincil doğruluk kaynağı olur: dört taşınabilir
+türün tamamı için native assertion'lar (durum kodu, gövde, JSONPath, XPath), düz
+bir Postman gövdesinin metne indirgeyeceği ham gövde alt-tipi (JSON / XML / HTML)
+ve istek zaman aşımı gelir. Bir projeyi veya test suite'ini Postman'a dışa
+aktarmak artık taşınabilir fidelity'si olan her isteğe `x-apinizer`'ı geri gömer;
+böylece Apinizer assertion'larınızı kayıpsız okur. Testnizer'a özel assertion
+türleri Testnizer'ın kendi kanalında kalır ve assertion'ı olmayan istekler temiz
+düz Postman olarak dışa aktarılır. Dışa aktarılan `testType` / `apiType` istek
+protokolünden türetilir (REST→RESOURCE, SOAP→WSDL, …), çünkü Testnizer'a içe
+alınan bir test standalone'dur ve Apinizer proxy bağı yoktur. Özelliğin tamamı
+eklemelidir — mevcut Postman / Insomnia / OpenAPI akışları değişmez.
+
 ## v1.4.35
 
 **Collection Runner artık her isteğin kendi Authorization header'ını, miras

--- a/website/src/lib/latest-release.ts
+++ b/website/src/lib/latest-release.ts
@@ -46,8 +46,8 @@ export interface RepoStats {
 }
 
 const FALLBACK: LatestRelease = {
-  tag: 'v1.4.35',
-  version: '1.4.35',
+  tag: 'v1.4.36',
+  version: '1.4.36',
   htmlUrl: 'https://github.com/apinizer/testnizer/releases/latest',
   publishedAt: null,
   assets: [],


### PR DESCRIPTION
## Summary

Apinizer test collections are Postman v2.1 collections carrying an `x-apinizer` extension. This PR makes Testnizer recognise and preserve that extension so an Apinizer-exported collection imports at full fidelity, and Testnizer's Postman export emits `x-apinizer` for the reverse trip. Ships as **v1.4.36**.

### Import (`importPostman`)
- `x-apinizer.assertions[]` → native `TestAssertion[]` (STATUS_CODE/BODY/JSONPATH/XPATH), the primary assertion source when present.
- `bodyRowType` recovers the raw-body sub-type (json/xml/html) Postman collapses to text when `options.raw.language` is absent.
- `timeoutSeconds` → `request_schema`.
- `schemaVersion` major gate: unknown major → plain-Postman fallback (with a warning). No extension → unchanged.

### Export (`buildPostmanCollection` — project + suite)
- native assertions → `x-apinizer.assertions[]` (only the 4 Apinizer-carryable kinds; Testnizer-only types stay in Testnizer's own channel).
- `testType`/`apiType` **derived from protocol**, not preserved — an imported test is proxy-free, so a stale `PROXY` type would be wrong to carry back.
- `x-apinizer` attached only when there is carryable fidelity → pure Postman exports stay clean.

### UI
- First-party **Apinizer** import card (import modal + sidebar Import dropdown) → routes to `importPostman` (branding/UX only). Mismatch guard accepts postman-detected content under the Apinizer card.

### Docs / contract
- Shared contract + both interop plans updated for the derived-`testType`/`apiType` rule (in `apinizer/md_files/testnizer-interop`, separate repo).

## Tests
- `tests/main/import-export-apinizer.test.ts` (11) + Apinizer cases in `tests/renderer/import-modal-mismatch.test.ts`. Full unit suite green (2012 passed).

## Release
- v1.4.36: notes, EN/TR changelog, FALLBACK bump, version bump included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)