### PR TITLE
fix(mTLS): send the configured client certificate + v1.4.37

### DIFF
--- a/docs/release-notes/v1.4.37.md
+++ b/docs/release-notes/v1.4.37.md
@@ -1,0 +1,33 @@
+## v1.4.37
+
+**Client certificates (mTLS) are now actually sent with the request.**
+
+- **Fixes a client cert that was configured but never presented:** a project
+  Client Certificate could silently fail to attach, so mTLS servers rejected the
+  call (e.g. Visa VDP answered *"Expected input credential was not present"*).
+  Two separate causes, both fixed:
+  - **Host matching.** The request matched certificates by the URL's bare
+    hostname (`sandbox.api.visa.com`), but the stored host was whatever you
+    typed — commonly a full base URL (`https://sandbox.api.visa.com`). The strict
+    exact-match dropped the cert. Matching is now tolerant of a pasted
+    scheme, port, path, and case, and supports `*` and `*.domain` patterns.
+  - **Reading the file at request time.** The certificate was stored as a file
+    *path* and re-read on every send. macOS blocks apps from reading
+    `~/Downloads`, `~/Desktop` and `~/Documents`, so that read failed and the
+    request went out with no certificate. Testnizer now reads the file **when you
+    pick it** (the moment access is granted) and keeps a copy in its own storage —
+    the same approach Postman uses — so protected folders are no longer a problem.
+- **No more silent failure:** if a configured client certificate still can't be
+  loaded, the request now fails with a clear message telling you why (missing
+  file, unreadable folder, wrong file type) instead of quietly sending the
+  request without the certificate.
+
+> **One-time step after updating:** open Project Settings → Certificates and
+> re-select your CRT/KEY (or PFX) files once, so Testnizer copies them into its
+> own storage.
+
+**Tests:** the mTLS pipeline is now exercised through the real certificate loader
+(the old tests reimplemented it inline and never ran the host filter or the
+file-read path — which is why this slipped). New coverage: host matching across
+scheme/port/wildcard variants plus a negative case, an unreadable-certificate
+error case, and pick-time file capture.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testnizer",
   "productName": "Testnizer",
-  "version": "1.4.36",
+  "version": "1.4.37",
   "description": "Testnizer — Cross-platform desktop API testing application",
   "main": "./out/main/index.js",
   "homepage": "https://www.testnizer.com",

--- a/src/main/db/certificate.repo.ts
+++ b/src/main/db/certificate.repo.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 import { getDb } from './database'
+import { certHostMatches } from '../lib/cert-host-match'
 
 export type CertificateKind = 'ca' | 'client'
 
@@ -36,13 +37,21 @@ export function listCertificates(projectId: string): CertificateRow[] {
 
 export function listCertificatesForHost(projectId: string, host: string): CertificateRow[] {
   const db = getDb()
-  return db
+  // Host matching happens in JS, NOT in SQL: a strict `host = ?` equality
+  // silently missed the common cases where the stored host carries a scheme
+  // ("https://sandbox.api.visa.com"), a port, a path, or different case — so the
+  // client cert was never attached and the request went out unauthenticated.
+  // `certHostMatches` normalises both sides (and supports '*'/'*.domain'/empty).
+  const rows = db
     .prepare(
       `SELECT * FROM certificates
-     WHERE project_id = ? AND enabled = 1
-       AND (kind = 'ca' OR host = ? OR host = '*' OR host IS NULL OR host = '')`,
+       WHERE project_id = ? AND enabled = 1
+       ORDER BY kind ASC, created_at ASC`,
     )
-    .all(projectId, host) as CertificateRow[]
+    .all(projectId) as CertificateRow[]
+  // CA certs are trust anchors applied to the whole project (their host is
+  // advisory); client certs are matched to the request host.
+  return rows.filter((r) => r.kind === 'ca' || certHostMatches(host, r.host))
 }
 
 export function createCertificate(input: CreateCertificateInput): CertificateRow {

--- a/src/main/ipc/certificate.handler.ts
+++ b/src/main/ipc/certificate.handler.ts
@@ -1,4 +1,7 @@
-import { ipcMain, dialog } from 'electron'
+import { ipcMain, dialog, app } from 'electron'
+import { readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { join, basename } from 'path'
+import { randomUUID } from 'crypto'
 import {
   listCertificates,
   createCertificate,
@@ -7,6 +10,10 @@ import {
   type CertificateKind,
 } from '../db/certificate.repo'
 import { encryptSecret } from '../lib/secure-storage'
+
+// Cap the file we're willing to ingest as certificate material (mirror the
+// request-time reader) so a mis-pick can't copy a multi-GB file into userData.
+const MAX_CERT_BYTES = 1024 * 1024 // 1 MiB
 
 interface Ok<T> {
   success: true
@@ -98,6 +105,36 @@ export function registerCertificateHandlers(): void {
     if (result.canceled || result.filePaths.length === 0) {
       return { success: false as const, error: 'Cancelled' }
     }
-    return { success: true as const, data: result.filePaths[0] }
+    const src = result.filePaths[0]
+    // Read the bytes NOW — while the user's explicit picker selection grants
+    // access — and copy them into the app's own storage (userData is never a
+    // macOS TCC-protected folder). Storing the ORIGINAL path and re-reading it
+    // at request time throws EPERM when the file lives in ~/Downloads,
+    // ~/Desktop or ~/Documents, so the request silently went out without the
+    // client cert (the reported mTLS bug). Postman avoids this by capturing the
+    // content at pick time; we do the same, and store the safe copy's path.
+    try {
+      const bytes = readFileSync(src)
+      if (bytes.length > MAX_CERT_BYTES) {
+        return {
+          success: false as const,
+          error: 'That file is larger than 1 MiB — it does not look like a certificate/key.',
+        }
+      }
+      const destDir = join(app.getPath('userData'), 'certs')
+      mkdirSync(destDir, { recursive: true })
+      // Keep the original filename (so the settings row stays recognisable),
+      // prefixed with a short unique token so repeated picks never collide.
+      const dest = join(destDir, `${randomUUID().slice(0, 8)}-${basename(src)}`)
+      writeFileSync(dest, bytes, { mode: 0o600 })
+      return { success: true as const, data: dest }
+    } catch (e) {
+      // Surface the failure at pick time instead of letting a broken path sit in
+      // settings and fail every future request.
+      return {
+        success: false as const,
+        error: `Couldn't read the selected file: ${e instanceof Error ? e.message : String(e)}`,
+      }
+    }
   })
 }

--- a/src/main/ipc/request.handler.ts
+++ b/src/main/ipc/request.handler.ts
@@ -53,54 +53,116 @@ const ALLOWED_CERT_EXTS = new Set(['.crt', '.cer', '.pem', '.key', '.pfx', '.p12
 // file can't OOM the main process.
 const MAX_CERT_BYTES = 1024 * 1024 // 1 MiB
 
-function safeReadCertFile(filePath: string): Buffer | null {
+type CertReadResult = { buf: Buffer } | { error: string }
+
+/** Human-readable, actionable reason for a filesystem error on a cert path. */
+function describeCertFsError(err: NodeJS.ErrnoException, filePath: string): string {
+  if (err?.code === 'ENOENT') return `file not found: ${filePath}`
+  if (err?.code === 'EPERM' || err?.code === 'EACCES') {
+    return (
+      `permission denied reading ${filePath}. On macOS an app cannot read ` +
+      `~/Downloads, ~/Desktop or ~/Documents without access — re-select the ` +
+      `certificate in Project Settings (Testnizer copies it into its own storage ` +
+      `on pick), move it to another folder, or grant Testnizer access under ` +
+      `System Settings › Privacy & Security › Files and Folders.`
+    )
+  }
+  return `cannot read ${filePath}: ${err?.message ?? String(err)}`
+}
+
+/**
+ * Read certificate/key material with safety rails (symlink resolution,
+ * extension whitelist, size cap) but return a DESCRIPTIVE reason on failure
+ * instead of a bare null. A configured client cert that silently failed to load
+ * used to send the request with NO certificate at all, so the server answered
+ * with a confusing "missing credential" error and the user never learned their
+ * .pem was unreadable (e.g. it sat in a macOS-protected folder).
+ */
+function readCertFile(filePath: string): CertReadResult {
+  let abs: string
   try {
     // Resolve symlinks first so an attacker can't bypass the extension
-    // whitelist by symlinking `attack.pem -> /etc/passwd` (the *target*
-    // is what matters for file content, not the link name).
-    const abs = realpathSync(resolve(filePath))
-    const ext = extname(abs).toLowerCase()
-    if (!ALLOWED_CERT_EXTS.has(ext)) return null
+    // whitelist by symlinking `attack.pem -> /etc/passwd` (the *target* is what
+    // matters for file content, not the link name).
+    abs = realpathSync(resolve(filePath))
+  } catch (e) {
+    return { error: describeCertFsError(e as NodeJS.ErrnoException, filePath) }
+  }
+  const ext = extname(abs).toLowerCase()
+  if (!ALLOWED_CERT_EXTS.has(ext)) {
+    return {
+      error: `unsupported file type "${ext || '(none)'}" — expected one of ${[...ALLOWED_CERT_EXTS].join(', ')} (${filePath})`,
+    }
+  }
+  try {
     const st = statSync(abs)
-    if (!st.isFile()) return null
-    if (st.size > MAX_CERT_BYTES) return null
-    return readFileSync(abs)
-  } catch {
-    return null
+    if (!st.isFile()) return { error: `not a regular file: ${filePath}` }
+    if (st.size > MAX_CERT_BYTES) {
+      return {
+        error: `certificate file is larger than the ${MAX_CERT_BYTES}-byte limit: ${filePath}`,
+      }
+    }
+    return { buf: readFileSync(abs) }
+  } catch (e) {
+    return { error: describeCertFsError(e as NodeJS.ErrnoException, filePath) }
   }
 }
 
-function loadCertificatesFor(
-  projectId: string | undefined,
-  url: string,
-): HttpRequestOptions['certificates'] {
-  if (!projectId) return undefined
+export interface CertLoadResult {
+  certificates?: HttpRequestOptions['certificates']
+  /**
+   * Set when a matched, ENABLED client cert could not be loaded. The request
+   * must then fail fast with this message rather than silently go out
+   * unauthenticated (which the server rejects with a cryptic error).
+   */
+  error?: string
+}
+
+/**
+ * Resolve the CA + client certificates configured for a request's host. Exported
+ * so the mTLS pipeline is exercised by the REAL code in tests (previously the
+ * tests reimplemented this inline, which is exactly why the host-match /
+ * silent-read-failure bugs slipped through).
+ */
+export function loadCertificatesFor(projectId: string | undefined, url: string): CertLoadResult {
+  if (!projectId) return {}
+  let host: string
   try {
-    const host = new URL(url).hostname
-    const rows = listCertificatesForHost(projectId, host)
-    if (rows.length === 0) return undefined
-    const caCerts: Buffer[] = []
-    let clientCert: { cert?: Buffer; key?: Buffer; pfx?: Buffer; passphrase?: string } | undefined
-    for (const r of rows) {
-      const passphrase = decryptSecret(r.passphrase) ?? undefined
-      if (r.kind === 'ca' && r.crt_path) {
-        const buf = safeReadCertFile(r.crt_path)
-        if (buf) caCerts.push(buf)
-      } else if (r.kind === 'client') {
-        if (r.pfx_path) {
-          const pfx = safeReadCertFile(r.pfx_path)
-          if (pfx) clientCert = { pfx, passphrase }
-        } else if (r.crt_path && r.key_path) {
-          const cert = safeReadCertFile(r.crt_path)
-          const key = safeReadCertFile(r.key_path)
-          if (cert && key) clientCert = { cert, key, passphrase }
-        }
+    host = new URL(url).hostname
+  } catch {
+    return {}
+  }
+  const rows = listCertificatesForHost(projectId, host)
+  if (rows.length === 0) return {}
+  const caCerts: Buffer[] = []
+  let clientCert: { cert?: Buffer; key?: Buffer; pfx?: Buffer; passphrase?: string } | undefined
+  for (const r of rows) {
+    const passphrase = decryptSecret(r.passphrase) ?? undefined
+    if (r.kind === 'ca' && r.crt_path) {
+      // CA certs are additive trust anchors — a read failure is non-fatal (the
+      // connection may still verify against the system trust store).
+      const res = readCertFile(r.crt_path)
+      if ('buf' in res) caCerts.push(res.buf)
+    } else if (r.kind === 'client') {
+      if (r.pfx_path) {
+        const res = readCertFile(r.pfx_path)
+        if ('error' in res)
+          return { error: `Client certificate for ${host} could not be loaded — ${res.error}` }
+        clientCert = { pfx: res.buf, passphrase }
+      } else if (r.crt_path && r.key_path) {
+        const certRes = readCertFile(r.crt_path)
+        if ('error' in certRes)
+          return { error: `Client certificate for ${host} could not be loaded — ${certRes.error}` }
+        const keyRes = readCertFile(r.key_path)
+        if ('error' in keyRes)
+          return {
+            error: `Client certificate key for ${host} could not be loaded — ${keyRes.error}`,
+          }
+        clientCert = { cert: certRes.buf, key: keyRes.buf, passphrase }
       }
     }
-    return { caCerts: caCerts.length ? caCerts : undefined, clientCert }
-  } catch {
-    return undefined
   }
+  return { certificates: { caCerts: caCerts.length ? caCerts : undefined, clientCert } }
 }
 
 // Map of in-flight request IDs → AbortController, so the renderer can call
@@ -148,11 +210,15 @@ export function registerRequestHandlers(): void {
       let controller: AbortController | undefined
       try {
         // If a project is known and no certificates were explicitly provided,
-        // attempt to pull matching CA / client certs from the project configuration.
+        // attempt to pull matching CA / client certs from the project config.
+        // A configured-but-unreadable client cert throws here so the request
+        // fails fast with a clear message instead of silently going out
+        // without the certificate (the reported mTLS bug).
         if (options._projectId && !options.certificates) {
-          const certs = loadCertificatesFor(options._projectId, options.url)
-          if (certs) {
-            options = { ...options, certificates: certs }
+          const { certificates, error } = loadCertificatesFor(options._projectId, options.url)
+          if (error) throw new Error(error)
+          if (certificates) {
+            options = { ...options, certificates }
           }
         }
         // Renderer sends `cipherPreset` / `ciphersCustom`; resolve to the actual

--- a/src/main/lib/cert-host-match.ts
+++ b/src/main/lib/cert-host-match.ts
@@ -1,0 +1,53 @@
+// Certificate host matching — pure, no DB / no Node APIs so it unit-tests
+// trivially and both the repo lookup and any future caller share one rule.
+//
+// WHY THIS EXISTS: a client certificate row stores a `host` the user typed in
+// the project's Certificates settings, and at request time we match it against
+// `new URL(url).hostname` (a BARE hostname, e.g. "sandbox.api.visa.com"). Users
+// routinely paste a full base URL ("https://sandbox.api.visa.com"), add a port
+// ("host:443"), a trailing path/slash, or mixed case. A strict `host = ?`
+// equality (the old SQL) silently failed to match every one of those, so the
+// request went out WITHOUT the client cert and the server answered with a
+// "missing client credential" error. Normalising both sides fixes that.
+
+/**
+ * Reduce a user-entered certificate host pattern to a bare, lowercase hostname
+ * so it can be compared against a URL's hostname. Strips scheme, userinfo,
+ * port, and any path/query. Empty input returns ''; the wildcard '*' passes
+ * through unchanged (it means "any host").
+ */
+export function normalizeCertHost(raw: string | null | undefined): string {
+  let h = (raw ?? '').trim().toLowerCase()
+  if (!h || h === '*') return h
+  h = h.replace(/^[a-z][a-z0-9+.-]*:\/\//, '') // strip scheme (https://, http://, …)
+  const at = h.lastIndexOf('@')
+  if (at >= 0) h = h.slice(at + 1) // strip userinfo (user:pass@)
+  h = h.split('/')[0].split('?')[0] // strip path / query
+  // Bracketed IPv6 ("[::1]" / "[::1]:8443") → the address inside the brackets.
+  const v6 = h.match(/^\[([^\]]+)\]/)
+  if (v6) return v6[1]
+  // Otherwise strip a trailing :port only when there's exactly one colon —
+  // a bare IPv6 ("::1") has several and must be left intact.
+  if ((h.match(/:/g) || []).length === 1) h = h.replace(/:\d+$/, '')
+  return h
+}
+
+/**
+ * Does a request hostname match a stored certificate host pattern?
+ * - empty / null / '*' pattern → matches every host (host is unset ⇒ global).
+ * - '*.example.com' → matches the apex `example.com` and any subdomain.
+ * - otherwise → normalized, case-insensitive hostname equality (tolerant of a
+ *   pasted scheme/port/path in the stored pattern).
+ */
+export function certHostMatches(requestHost: string, pattern: string | null | undefined): boolean {
+  const np = normalizeCertHost(pattern)
+  if (np === '' || np === '*') return true
+  const rh = normalizeCertHost(requestHost)
+  if (!rh) return false
+  if (np === rh) return true
+  if (np.startsWith('*.')) {
+    const base = np.slice(2)
+    return rh === base || rh.endsWith('.' + base)
+  }
+  return false
+}

--- a/tests/main/cert-host-match.test.ts
+++ b/tests/main/cert-host-match.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeCertHost, certHostMatches } from '../../src/main/lib/cert-host-match'
+
+describe('normalizeCertHost', () => {
+  it('passes a bare hostname through (lowercased)', () => {
+    expect(normalizeCertHost('sandbox.api.visa.com')).toBe('sandbox.api.visa.com')
+    expect(normalizeCertHost('SANDBOX.Api.Visa.COM')).toBe('sandbox.api.visa.com')
+  })
+
+  it('strips a scheme prefix (the real bug: user pasted the base URL)', () => {
+    expect(normalizeCertHost('https://sandbox.api.visa.com')).toBe('sandbox.api.visa.com')
+    expect(normalizeCertHost('http://sandbox.api.visa.com')).toBe('sandbox.api.visa.com')
+  })
+
+  it('strips a port, a path, a trailing slash, and userinfo', () => {
+    expect(normalizeCertHost('sandbox.api.visa.com:443')).toBe('sandbox.api.visa.com')
+    expect(normalizeCertHost('https://sandbox.api.visa.com/vdp/helloworld')).toBe(
+      'sandbox.api.visa.com',
+    )
+    expect(normalizeCertHost('https://sandbox.api.visa.com/')).toBe('sandbox.api.visa.com')
+    expect(normalizeCertHost('https://user:pass@sandbox.api.visa.com:8443/x')).toBe(
+      'sandbox.api.visa.com',
+    )
+  })
+
+  it('unwraps IPv6 brackets and strips the port', () => {
+    expect(normalizeCertHost('https://[::1]:8443/')).toBe('::1')
+  })
+
+  it('returns empty for blank input and passes * through', () => {
+    expect(normalizeCertHost('')).toBe('')
+    expect(normalizeCertHost(null)).toBe('')
+    expect(normalizeCertHost(undefined)).toBe('')
+    expect(normalizeCertHost('  ')).toBe('')
+    expect(normalizeCertHost('*')).toBe('*')
+  })
+})
+
+describe('certHostMatches', () => {
+  const REQ = 'sandbox.api.visa.com'
+
+  it('matches when the stored pattern carries a scheme (regression for the mTLS bug)', () => {
+    // Exactly what the user typed in the Certificates settings.
+    expect(certHostMatches(REQ, 'https://sandbox.api.visa.com')).toBe(true)
+  })
+
+  it('matches port / path / trailing-slash / case variants of the stored host', () => {
+    expect(certHostMatches(REQ, 'sandbox.api.visa.com:443')).toBe(true)
+    expect(certHostMatches(REQ, 'https://sandbox.api.visa.com/vdp/helloworld')).toBe(true)
+    expect(certHostMatches(REQ, 'https://sandbox.api.visa.com/')).toBe(true)
+    expect(certHostMatches(REQ, 'SANDBOX.API.VISA.COM')).toBe(true)
+  })
+
+  it('matches exact bare hostname', () => {
+    expect(certHostMatches(REQ, 'sandbox.api.visa.com')).toBe(true)
+  })
+
+  it('treats empty / null / * as "any host"', () => {
+    expect(certHostMatches(REQ, '')).toBe(true)
+    expect(certHostMatches(REQ, null)).toBe(true)
+    expect(certHostMatches(REQ, undefined)).toBe(true)
+    expect(certHostMatches(REQ, '*')).toBe(true)
+  })
+
+  it('supports *.domain wildcards (apex + subdomains)', () => {
+    expect(certHostMatches('sandbox.api.visa.com', '*.visa.com')).toBe(true)
+    expect(certHostMatches('visa.com', '*.visa.com')).toBe(true)
+    expect(certHostMatches('sandbox.api.visa.com', 'https://*.visa.com')).toBe(true)
+    expect(certHostMatches('evil-visa.com', '*.visa.com')).toBe(false)
+  })
+
+  it('does NOT match a different host (negative case the old tests never covered)', () => {
+    expect(certHostMatches(REQ, 'other.example.com')).toBe(false)
+    expect(certHostMatches(REQ, 'https://api.example.com')).toBe(false)
+    // a superstring must not match by accident
+    expect(certHostMatches('visa.com.attacker.net', 'visa.com')).toBe(false)
+  })
+})

--- a/tests/main/cert-pipeline.test.ts
+++ b/tests/main/cert-pipeline.test.ts
@@ -82,78 +82,38 @@ async function importWithMockedDb(rows: {
     decryptSecret: (s: string | null) => s,
   }))
 
+  // Exercise the REAL, exported loadCertificatesFor — not an inline copy. The
+  // old harness reimplemented the handler's logic, which is exactly why the
+  // host-match + silent-read-failure bugs were never caught (the copy read
+  // files unconditionally and never ran the real host filter / error path).
   const mod = await import('../../src/main/ipc/request.handler')
-  // loadCertificatesFor is private — re-export through a small probe.
-  // Since it's not exported, we exercise it via the public path. For unit
-  // testing the lookup itself we use the real certificate.repo through
-  // the mocked DB and read the shape of the value the engine receives.
-  // Trick: we monkey-patch the engine to capture the options it received.
-  const certRepo = await import('../../src/main/db/certificate.repo')
-
-  // Recreate loadCertificatesFor inline using the same logic the handler
-  // uses — this guarantees the test will fail if the handler's logic
-  // diverges, since the certificate.repo + safeReadCertFile path is shared.
-  return {
-    loadCertificatesFor: (projectId: string, url: string) => {
-      let host = ''
-      try {
-        host = new URL(url).hostname
-      } catch {
-        return null
-      }
-      const list = certRepo.listCertificatesForHost(projectId, host)
-      if (list.length === 0) return null
-      // Replicate the handler's assembly so we test the same shape.
-      const out: {
-        caCerts?: Buffer[]
-        clientCert?: { cert?: Buffer; key?: Buffer; pfx?: Buffer; passphrase?: string }
-      } = {}
-      for (const r of list) {
-        if (r.kind === 'ca' && r.crt_path) {
-          const buf = require('node:fs').readFileSync(r.crt_path)
-          out.caCerts = [...(out.caCerts ?? []), buf]
-        } else if (r.kind === 'client') {
-          out.clientCert = out.clientCert ?? {}
-          if (r.pfx_path) {
-            out.clientCert.pfx = require('node:fs').readFileSync(r.pfx_path)
-          } else {
-            if (r.crt_path) out.clientCert.cert = require('node:fs').readFileSync(r.crt_path)
-            if (r.key_path) out.clientCert.key = require('node:fs').readFileSync(r.key_path)
-          }
-          if (r.passphrase) out.clientCert.passphrase = r.passphrase
-        }
-      }
-      return out
-    },
-    // module import side-effect — also surfaces a vitest "uses unused" warning
-    // if we forget; keep `mod` referenced so the suite fails loudly on a
-    // future rename.
-    ...({ mod } as object),
-  }
+  return { loadCertificatesFor: mod.loadCertificatesFor }
 }
 
-// ───────── Certificate repo host-matching ─────────
+// ───────── loadCertificatesFor — host matching + read pipeline ─────────
+//
+// These exercise the REAL exported loadCertificatesFor, which returns
+// `{ certificates?, error? }`. `error` is set (and the request fails fast)
+// when a matched, enabled client cert can't be read — no more silent drop.
 
-describe('certificate.repo — listCertificatesForHost', () => {
+interface Certs {
+  caCerts?: Buffer[]
+  clientCert?: { cert?: Buffer; key?: Buffer; pfx?: Buffer; passphrase?: string }
+}
+type Result = { certificates?: Certs; error?: string }
+
+describe('loadCertificatesFor — host matching', () => {
   it('returns CA certs regardless of host (CA is global to the project)', async () => {
     const caPath = join(tmpRoot, 'root.crt')
     writeFileSync(caPath, '-----BEGIN CERTIFICATE-----\nCA-FAKE\n-----END CERTIFICATE-----')
     const { loadCertificatesFor } = await importWithMockedDb({
-      certs: [
-        {
-          kind: 'ca',
-          host: 'somewhere-else.example',
-          crt_path: caPath,
-        },
-      ],
+      certs: [{ kind: 'ca', host: 'somewhere-else.example', crt_path: caPath }],
     })
-    const result = loadCertificatesFor('p1', 'https://expired.badssl.com/') as {
-      caCerts?: Buffer[]
-    } | null
-    expect(result).not.toBeNull()
-    expect(result?.caCerts?.length).toBe(1)
+    const result = loadCertificatesFor('p1', 'https://expired.badssl.com/') as Result
     // A CA's `host` column is advisory — host mismatch on the request URL
     // must NOT exclude the CA from the trust list.
+    expect(result.certificates?.caCerts?.length).toBe(1)
+    expect(result.error).toBeUndefined()
   })
 
   it('matches client cert on exact host', async () => {
@@ -162,21 +122,11 @@ describe('certificate.repo — listCertificatesForHost', () => {
     writeFileSync(certPath, '-----BEGIN CERTIFICATE-----\nC\n-----END CERTIFICATE-----')
     writeFileSync(keyPath, '-----BEGIN PRIVATE KEY-----\nK\n-----END PRIVATE KEY-----')
     const { loadCertificatesFor } = await importWithMockedDb({
-      certs: [
-        {
-          kind: 'client',
-          host: 'client.badssl.com',
-          crt_path: certPath,
-          key_path: keyPath,
-        },
-      ],
+      certs: [{ kind: 'client', host: 'client.badssl.com', crt_path: certPath, key_path: keyPath }],
     })
-    const result = loadCertificatesFor('p1', 'https://client.badssl.com/') as {
-      clientCert?: { cert?: Buffer; key?: Buffer }
-    } | null
-    expect(result).not.toBeNull()
-    expect(result?.clientCert?.cert).toBeInstanceOf(Buffer)
-    expect(result?.clientCert?.key).toBeInstanceOf(Buffer)
+    const result = loadCertificatesFor('p1', 'https://client.badssl.com/') as Result
+    expect(result.certificates?.clientCert?.cert).toBeInstanceOf(Buffer)
+    expect(result.certificates?.clientCert?.key).toBeInstanceOf(Buffer)
   })
 
   it('matches client cert on wildcard host', async () => {
@@ -185,20 +135,53 @@ describe('certificate.repo — listCertificatesForHost', () => {
     writeFileSync(certPath, 'C')
     writeFileSync(keyPath, 'K')
     const { loadCertificatesFor } = await importWithMockedDb({
+      certs: [{ kind: 'client', host: '*', crt_path: certPath, key_path: keyPath }],
+    })
+    const result = loadCertificatesFor('p1', 'https://random.example.com/') as Result
+    expect(result.certificates?.clientCert?.cert).toBeInstanceOf(Buffer)
+  })
+
+  it('matches a client cert whose stored host carries a scheme (regression: mTLS not sent)', async () => {
+    // The exact reported bug: the user pasted "https://sandbox.api.visa.com"
+    // into the Certificates settings, but the request host is the bare
+    // hostname. The old `host = ?` SQL never matched, so the cert was dropped
+    // and the server answered "Expected input credential was not present".
+    const certPath = join(tmpRoot, 'visa.crt')
+    const keyPath = join(tmpRoot, 'visa.key')
+    writeFileSync(certPath, '-----BEGIN CERTIFICATE-----\nVISA\n-----END CERTIFICATE-----')
+    writeFileSync(keyPath, '-----BEGIN PRIVATE KEY-----\nVISA-KEY\n-----END PRIVATE KEY-----')
+    const { loadCertificatesFor } = await importWithMockedDb({
       certs: [
         {
           kind: 'client',
-          host: '*',
+          host: 'https://sandbox.api.visa.com',
           crt_path: certPath,
           key_path: keyPath,
         },
       ],
     })
-    const result = loadCertificatesFor('p1', 'https://random.example.com/') as {
-      clientCert?: { cert?: Buffer }
-    } | null
-    expect(result).not.toBeNull()
-    expect(result?.clientCert?.cert).toBeInstanceOf(Buffer)
+    const result = loadCertificatesFor('p1', 'https://sandbox.api.visa.com/vdp/helloworld') as Result
+    expect(result.certificates?.clientCert?.cert).toBeInstanceOf(Buffer)
+    expect(result.certificates?.clientCert?.key).toBeInstanceOf(Buffer)
+  })
+
+  it('does NOT attach a client cert whose host does not match the request (negative case)', async () => {
+    // Previously untestable: the DB mock returned every row regardless of the
+    // WHERE clause, so host mismatch was never exercised. Now that matching is
+    // in JS, a client cert scoped to a different host must be excluded.
+    const certPath = join(tmpRoot, 'other.crt')
+    const keyPath = join(tmpRoot, 'other.key')
+    writeFileSync(certPath, 'C')
+    writeFileSync(keyPath, 'K')
+    const { loadCertificatesFor } = await importWithMockedDb({
+      certs: [
+        { kind: 'client', host: 'other.example.com', crt_path: certPath, key_path: keyPath },
+      ],
+    })
+    const result = loadCertificatesFor('p1', 'https://sandbox.api.visa.com/vdp/helloworld') as Result
+    // Only one (non-matching) client cert row → nothing matched → no certs, no error.
+    expect(result.certificates).toBeUndefined()
+    expect(result.error).toBeUndefined()
   })
 
   it('prefers PFX path over cert/key when both are present (PFX wins)', async () => {
@@ -220,41 +203,55 @@ describe('certificate.repo — listCertificatesForHost', () => {
         },
       ],
     })
-    const result = loadCertificatesFor('p1', 'https://host.test/') as {
-      clientCert?: { pfx?: Buffer; cert?: Buffer; key?: Buffer; passphrase?: string }
-    } | null
-    expect(result?.clientCert?.pfx?.toString()).toBe('PFX-BYTES')
-    expect(result?.clientCert?.passphrase).toBe('pw')
+    const result = loadCertificatesFor('p1', 'https://host.test/') as Result
+    expect(result.certificates?.clientCert?.pfx?.toString()).toBe('PFX-BYTES')
+    expect(result.certificates?.clientCert?.passphrase).toBe('pw')
     // When PFX is provided the engine ignores cert/key — we mirror that here.
-    expect(result?.clientCert?.cert).toBeUndefined()
-    expect(result?.clientCert?.key).toBeUndefined()
+    expect(result.certificates?.clientCert?.cert).toBeUndefined()
+    expect(result.certificates?.clientCert?.key).toBeUndefined()
+  })
+
+  it('surfaces an error (does NOT silently drop) when a matched client cert file cannot be read', async () => {
+    // The second half of the reported bug: the cert row matched but its file
+    // was unreadable (e.g. macOS EPERM on ~/Downloads). The request used to go
+    // out with NO certificate and got a cryptic server error; now the load
+    // fails fast with a descriptive message that the caller throws.
+    const { loadCertificatesFor } = await importWithMockedDb({
+      certs: [
+        {
+          kind: 'client',
+          host: 'sandbox.api.visa.com',
+          crt_path: join(tmpRoot, 'does-not-exist.pem'),
+          key_path: join(tmpRoot, 'does-not-exist.key'),
+        },
+      ],
+    })
+    const result = loadCertificatesFor('p1', 'https://sandbox.api.visa.com/vdp/helloworld') as Result
+    expect(result.certificates).toBeUndefined()
+    expect(result.error).toMatch(/could not be loaded/i)
+    expect(result.error).toMatch(/file not found/i)
   })
 
   it('skips disabled rows entirely (enabled = 0)', async () => {
     const caPath = join(tmpRoot, 'disabled.crt')
     writeFileSync(caPath, 'CA')
     const { loadCertificatesFor } = await importWithMockedDb({
-      certs: [
-        {
-          kind: 'ca',
-          host: null,
-          crt_path: caPath,
-          enabled: 0,
-        },
-      ],
+      certs: [{ kind: 'ca', host: null, crt_path: caPath, enabled: 0 }],
     })
-    const result = loadCertificatesFor('p1', 'https://example.com/')
-    expect(result).toBeNull()
+    const result = loadCertificatesFor('p1', 'https://example.com/') as Result
+    expect(result.certificates).toBeUndefined()
+    expect(result.error).toBeUndefined()
   })
 
-  it('returns null when the URL is malformed (no host to match)', async () => {
+  it('returns nothing when the URL is malformed (no host to match)', async () => {
     const { loadCertificatesFor } = await importWithMockedDb({
       certs: [{ kind: 'ca', host: null, crt_path: join(tmpRoot, 'whatever.crt') }],
     })
     // No file write — the lookup must short-circuit on the URL parse rather
     // than blowing up further down the pipeline.
-    const result = loadCertificatesFor('p1', 'not a url')
-    expect(result).toBeNull()
+    const result = loadCertificatesFor('p1', 'not a url') as Result
+    expect(result.certificates).toBeUndefined()
+    expect(result.error).toBeUndefined()
   })
 })
 

--- a/tests/main/handlers/certificate.test.ts
+++ b/tests/main/handlers/certificate.test.ts
@@ -2,7 +2,10 @@
  * Smoke tests for `certificate:*` IPC handlers.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   setupHandlerHarness,
   makeElectronMock,
@@ -105,6 +108,18 @@ describe('certificate:update + delete', () => {
 })
 
 describe('certificate:pickFile', () => {
+  let srcDir: string
+  beforeEach(() => {
+    srcDir = mkdtempSync(join(tmpdir(), 'testnizer-pick-'))
+  })
+  afterEach(() => {
+    try {
+      rmSync(srcDir, { recursive: true, force: true })
+    } catch {
+      /* best-effort */
+    }
+  })
+
   it('returns success: false on cancel', async () => {
     dialogMock.showOpenDialog.mockResolvedValueOnce({ canceled: true, filePaths: [] })
     const res = (await harness.invoke('certificate:pickFile', 'crt')) as {
@@ -114,16 +129,40 @@ describe('certificate:pickFile', () => {
     expect(res.success).toBe(false)
   })
 
-  it('returns the chosen file path on success', async () => {
-    dialogMock.showOpenDialog.mockResolvedValueOnce({
-      canceled: false,
-      filePaths: ['/picked/cert.crt'],
-    })
+  it('copies the picked file into app storage at pick time (Postman-style capture)', async () => {
+    // The fix for the reported mTLS bug: reading the file NOW (while the picker
+    // grant is live) and storing a copy — instead of storing the original path
+    // and re-reading it at request time, which macOS blocks for ~/Downloads.
+    const src = join(srcDir, 'cert.crt')
+    writeFileSync(src, '-----BEGIN CERTIFICATE-----\nHELLO\n-----END CERTIFICATE-----')
+    dialogMock.showOpenDialog.mockResolvedValueOnce({ canceled: false, filePaths: [src] })
+
     const res = (await harness.invoke('certificate:pickFile', 'crt')) as {
       success: boolean
       data?: string
     }
     expect(res.success).toBe(true)
-    expect(res.data).toBe('/picked/cert.crt')
+    // Stored path lives in app userData (mock: /tmp/testnizer-test/certs), NOT
+    // the original picked location, and keeps the original filename.
+    expect(res.data).toContain('/certs/')
+    expect(res.data).not.toBe(src)
+    expect(res.data?.endsWith('cert.crt')).toBe(true)
+    // The copy is byte-identical to the source.
+    expect(readFileSync(res.data as string, 'utf8')).toContain('HELLO')
+  })
+
+  it('surfaces an error at pick time when the selected file cannot be read', async () => {
+    // No silent success: if the picked file is unreadable, tell the user now
+    // rather than letting a broken path sit in settings and fail every request.
+    dialogMock.showOpenDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePaths: [join(srcDir, 'nope.crt')], // never written
+    })
+    const res = (await harness.invoke('certificate:pickFile', 'crt')) as {
+      success: boolean
+      error?: string
+    }
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/couldn't read/i)
   })
 })

--- a/website/src/content/docs/changelog.md
+++ b/website/src/content/docs/changelog.md
@@ -10,6 +10,26 @@ source of truth for release descriptions — the CI release job mirrors
 each entry into the matching [GitHub Release](https://github.com/apinizer/testnizer/releases),
 where signed installers and SHA-256 checksums are attached.
 
+## v1.4.37
+
+**Client certificates (mTLS) are now actually sent with the request.**
+
+A project Client Certificate could silently fail to attach, so mTLS servers
+rejected the call (e.g. Visa VDP answered *"Expected input credential was not
+present"*). Two separate causes are fixed. First, host matching: the request
+matched certificates by the URL's bare hostname (`sandbox.api.visa.com`), but the
+stored host was whatever you typed — commonly a full base URL
+(`https://sandbox.api.visa.com`) — and the strict exact-match dropped the cert.
+Matching now tolerates a pasted scheme, port, path and case, and supports `*` and
+`*.domain` patterns. Second, the certificate was stored as a file *path* and
+re-read on every send; macOS blocks apps from reading `~/Downloads`, `~/Desktop`
+and `~/Documents`, so that read failed and the request went out with no cert.
+Testnizer now reads the file **when you pick it** and keeps a copy in its own
+storage (the same approach Postman uses), and if a configured cert still can't be
+loaded the request fails with a clear message instead of silently omitting it.
+After updating, re-select your CRT/KEY (or PFX) files once in Project Settings →
+Certificates.
+
 ## v1.4.36
 
 **Import Apinizer test collections — and export back to them — at full fidelity.**

--- a/website/src/content/docs/tr/changelog.md
+++ b/website/src/content/docs/tr/changelog.md
@@ -11,6 +11,26 @@ girdiyi karşılığı olan [GitHub Release](https://github.com/apinizer/testniz
 sayfasına aynalar; imzalı yükleyiciler ve SHA-256 sağlama toplamları
 orada eklenir.
 
+## v1.4.37
+
+**İstemci sertifikaları (mTLS) artık istekle birlikte gerçekten gönderiliyor.**
+
+Bir projedeki İstemci Sertifikası sessizce eklenemeyebiliyordu; bu yüzden mTLS
+sunucuları isteği reddediyordu (ör. Visa VDP *"Expected input credential was not
+present"* dönüyordu). İki ayrı neden düzeltildi. Birincisi host eşleşmesi: istek,
+sertifikaları URL'nin çıplak host adıyla (`sandbox.api.visa.com`) eşliyordu; ama
+saklanan host senin yazdığın şeydi — çoğu zaman tam bir temel URL
+(`https://sandbox.api.visa.com`) — ve katı birebir eşleşme sertifikayı düşürüyordu.
+Eşleşme artık yapıştırılan şema, port, path ve büyük/küçük harf farkını tolere
+ediyor ve `*` ile `*.domain` desenlerini destekliyor. İkincisi, sertifika bir dosya
+*yolu* olarak saklanıp her göndermede yeniden okunuyordu; macOS uygulamaların
+`~/Downloads`, `~/Desktop` ve `~/Documents`'i okumasını engellediği için bu okuma
+başarısız oluyor ve istek sertifikasız gidiyordu. Testnizer artık dosyayı **sen
+seçtiğin an** okuyup kendi deposunda bir kopya tutuyor (Postman'in yaptığı gibi) ve
+yapılandırılmış bir sertifika yine de yüklenemezse, isteği sessizce sertifikasız
+göndermek yerine net bir hatayla durduruyor. Güncelledikten sonra Project Settings
+→ Certificates'ten CRT/KEY (veya PFX) dosyalarını bir kez yeniden seç.
+
 ## v1.4.36
 
 **Apinizer test koleksiyonlarını tam-fidelity içe alın — ve onlara geri dışa aktarın.**

--- a/website/src/lib/latest-release.ts
+++ b/website/src/lib/latest-release.ts
@@ -46,8 +46,8 @@ export interface RepoStats {
 }
 
 const FALLBACK: LatestRelease = {
-  tag: 'v1.4.36',
-  version: '1.4.36',
+  tag: 'v1.4.37',
+  version: '1.4.37',
   htmlUrl: 'https://github.com/apinizer/testnizer/releases/latest',
   publishedAt: null,
   assets: [],


### PR DESCRIPTION
## Summary

A configured project **Client Certificate** was never attached to the request, so mTLS servers rejected the call (e.g. Visa VDP: *"Expected input credential was not present"*). Ships as **v1.4.37**. Two independent defects:

1. **Host matching** — the request matched certs by the URL's bare hostname (`sandbox.api.visa.com`) but the stored host was whatever the user typed, commonly a full base URL (`https://sandbox.api.visa.com`). The strict `host = ?` SQL never matched → cert dropped. Matching now runs in a pure normalised helper (`cert-host-match.ts`) tolerant of scheme/port/path/case, with `*` / `*.domain` / empty support.

2. **Read at request time / macOS-protected folders** — the row stored only the file PATH and re-read it on every send. macOS blocks reading `~/Downloads` / `~/Desktop` / `~/Documents` (TCC → EPERM), so the read failed and the request silently went out with no cert. `certificate:pickFile` now reads the bytes **at pick time** and copies them into `userData/certs` (Postman-style capture). A matched-but-unreadable client cert now **fails the request with a clear message** instead of silently omitting it.

## Why tests missed it
`cert-pipeline.test.ts` reimplemented `loadCertificatesFor` inline and its DB mock ignored the `WHERE` clause, so the real host filter + file-read path were never exercised. The suite now drives the **real exported** `loadCertificatesFor`, and adds:
- host matching: scheme / port / wildcard / negative cases (`cert-host-match.test.ts` + pipeline)
- unreadable-cert → error (not silent)
- `pickFile` copy + read-error cases

Full unit suite green (2026 passed; the only red is the local, gitignored `apiops-real-import` scratch test that reads a personal file).

## User note
Existing cert rows point at the original file path — re-select the CRT/KEY (or PFX) files once so they're copied into app storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)