### PR TITLE
docs(website): correct "No login" claim to "No cloud login"

### DIFF
--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -19,8 +19,9 @@ If you want to verify the integrity of the installer before running it, see [Ver
 
 ## First launch
 
-Testnizer opens to a Welcome screen. There is no account creation, no login, no
-"sign in to sync" prompt. You can:
+Testnizer opens to a Welcome screen. There is no account creation, no cloud
+login, no "sign in to sync" prompt. (You can optionally protect the app with a
+local password — it is scrypt-hashed and never leaves your machine.) You can:
 
 - **Create a new workspace** — workspaces hold projects; projects hold collections
 - **Open an existing workspace** — point at a folder on disk

--- a/website/src/content/docs/tr/getting-started.md
+++ b/website/src/content/docs/tr/getting-started.md
@@ -16,8 +16,10 @@ Yükleyiciyi çalıştırmadan önce bütünlüğünü doğrulamak isterseniz, [
 
 ## İlk açılış
 
-Testnizer, Hoş Geldiniz ekranıyla açılır. Hesap oluşturma yok, giriş yok,
-"senkronize etmek için oturum açın" istemi yok. Şunları yapabilirsiniz:
+Testnizer, Hoş Geldiniz ekranıyla açılır. Hesap oluşturma yok, bulut girişi yok,
+"senkronize etmek için oturum açın" istemi yok. (İsterseniz uygulamayı yerel bir
+parolayla koruyabilirsiniz — parola scrypt ile hash'lenir ve makinenizden asla
+çıkmaz.) Şunları yapabilirsiniz:
 
 - **Yeni bir çalışma alanı oluştur** — çalışma alanları proje barındırır; projeler koleksiyon barındırır
 - **Mevcut bir çalışma alanını aç** — diskteki bir klasörü işaret et

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -14,7 +14,7 @@ const guarantees = [
   {
     icon: icons.shieldOff,
     title: '100% Offline',
-    body: 'Air-gapped networks supported. The app sends API requests only to the targets you configure — never to a vendor server. No login, no account, no telemetry.',
+    body: 'Air-gapped networks supported. The app sends API requests only to the targets you configure — never to a vendor server. No cloud login, no account, no telemetry.',
   },
   {
     icon: icons.hardDrive,

--- a/website/src/pages/security.astro
+++ b/website/src/pages/security.astro
@@ -23,7 +23,7 @@ const principles = [
 
 const claims = [
   { label: 'No telemetry', body: "We don't have an analytics endpoint to disable. There is no opt-in either." },
-  { label: 'No login', body: 'No account creation. No SSO. No vendor server even knows the app exists.' },
+  { label: 'No cloud login', body: 'No account creation. No SSO. The optional app lock is a local, scrypt-hashed password on your machine — no vendor server even knows the app exists.' },
   { label: 'No cloud sync', body: "Your collections live in a local SQLite. Backups are your responsibility. That's the trade-off." },
   { label: 'No background egress', body: "The renderer's CSP blocks it. The main process only opens connections you trigger." },
   { label: 'No third-party JWT decode', body: "Decode runs locally with Node's crypto module. The token never leaves the process." },

--- a/website/src/pages/tr/index.astro
+++ b/website/src/pages/tr/index.astro
@@ -14,7 +14,7 @@ const guarantees = [
   {
     icon: icons.shieldOff,
     title: '%100 Çevrimdışı',
-    body: 'Hava boşluklu ağlar desteklenir. Uygulama, API isteklerini yalnızca sizin yapılandırdığınız hedeflere gönderir — asla bir satıcı sunucusuna değil. Giriş yok, hesap yok, telemetri yok.',
+    body: 'Hava boşluklu ağlar desteklenir. Uygulama, API isteklerini yalnızca sizin yapılandırdığınız hedeflere gönderir — asla bir satıcı sunucusuna değil. Bulut girişi yok, hesap yok, telemetri yok.',
   },
   {
     icon: icons.hardDrive,

--- a/website/src/pages/tr/security.astro
+++ b/website/src/pages/tr/security.astro
@@ -23,7 +23,7 @@ const principles = [
 
 const claims = [
   { label: 'Telemetri yok', body: 'Devre dışı bırakılacak bir analitik uç noktamız yoktur. Katılım seçeneği de yoktur.' },
-  { label: 'Giriş yok', body: 'Hesap oluşturma yok. SSO yok. Hiçbir satıcı sunucusu uygulamanın varlığından bile haberdar olmaz.' },
+  { label: 'Bulut girişi yok', body: 'Hesap oluşturma yok. SSO yok. Opsiyonel uygulama kilidi, makinenizde scrypt ile hash\'lenen yerel bir paroladır — hiçbir satıcı sunucusu uygulamanın varlığından bile haberdar olmaz.' },
   { label: 'Bulut senkronizasyonu yok', body: 'Koleksiyonlarınız yerel bir SQLite içinde yaşar. Yedeklemeler sizin sorumluluğunuzdadır. Bu, yapılan takas budur.' },
   { label: 'Arka plan çıkışı yok', body: "Renderer'ın CSP'si bunu engeller. Ana süreç yalnızca sizin tetiklediğiniz bağlantıları açar." },
   { label: 'Üçüncü taraf JWT çözme yok', body: "Çözme, Node'un crypto modülüyle yerel olarak çalışır. Token asla süreçten çıkmaz." },


### PR DESCRIPTION
The app offers an optional local app-lock password (scrypt-hashed, stored only in the local SQLite), so the blanket "No login" claim on the security page was inaccurate.

- Security page card (EN + TR): "No login" → "No cloud login", body now states what the optional local lock is.
- Homepage privacy line (EN + TR): "No login, no account, no telemetry" → "No cloud login, …".
- Getting-started docs (EN + TR): same correction + one-line note about the optional local password.

Website-only change (`paths-ignore` keeps the app build untouched); Astro build verified locally — 80 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)