### PR TITLE
fix(auth): verify Active Directory passwords in the OS-password reset

### DIFF
--- a/src/main/lib/os-auth.ts
+++ b/src/main/lib/os-auth.ts
@@ -80,15 +80,34 @@ export function cleanPowerShellStderr(raw: string): string {
   return (i >= 0 ? raw.slice(0, i) : raw).trim()
 }
 
-function verifyWindows(username: string, password: string): Promise<OsAuthResult> {
-  return new Promise((resolve) => {
-    // Credentials ride env vars so they never appear in the process command
-    // line visible to other users. The verdict is printed as TZ_OK / TZ_FAIL.
-    const script = `
+/**
+ * The PowerShell verification program, exported for tests (the LogonUser /
+ * AccountManagement calls themselves only run on Windows).
+ *
+ * Attempt chain — ordered local-first, then Active Directory (issue #82: a
+ * domain account always failed because only `domain '.'` = local SAM and the
+ * two ValidateCredentials contexts were tried; the Domain context throws when
+ * the DC is unreachable, so a laptop off the corporate network/VPN reported
+ * "incorrect password" for a password Windows itself accepts via its cache):
+ *
+ *   1. LogonUser  '.'          NETWORK(3)   — local account
+ *   2. LogonUser  USERDOMAIN   NETWORK(3)   — AD account, DC reachable
+ *   3. LogonUser  USERDOMAIN   INTERACTIVE(2) — AD policies that reject NETWORK
+ *   4. LogonUser  USERDOMAIN   CACHED_INTERACTIVE(11) — DC unreachable; checks
+ *      the same cached verifier the Windows lock screen uses
+ *   5. LogonUser  UPN (user@USERDNSDOMAIN)  NETWORK(3)
+ *   6. PrincipalContext Machine → Domain ValidateCredentials (legacy fallback)
+ *
+ * A failure on a domain-joined machine prints TZ_FAIL_DOMAIN so the caller can
+ * say "DC may be unreachable" instead of only "incorrect password".
+ */
+export function buildWindowsAuthScript(): string {
+  return `
 $ProgressPreference = 'SilentlyContinue'
 $ErrorActionPreference = 'SilentlyContinue'
 $u = $env:TESTNIZER_OS_USER
 $p = $env:TESTNIZER_OS_PW
+$domainJoined = ($env:USERDOMAIN) -and ($env:USERDOMAIN -ne $env:COMPUTERNAME)
 try {
   $sig = @'
 [DllImport("advapi32.dll", SetLastError=true)]
@@ -98,8 +117,21 @@ public static extern bool CloseHandle(System.IntPtr handle);
 '@
   $api = Add-Type -MemberDefinition $sig -Name 'TZLogon' -Namespace 'TZ' -PassThru
   $tok = [System.IntPtr]::Zero
+  $ok = $false
   # LOGON32_LOGON_NETWORK = 3, LOGON32_PROVIDER_DEFAULT = 0; domain '.' = local SAM
-  if ($api::LogonUser($u, '.', $p, 3, 0, [ref]$tok)) { [void]$api::CloseHandle($tok); Write-Output 'TZ_OK'; exit 0 }
+  if ($api::LogonUser($u, '.', $p, 3, 0, [ref]$tok)) { $ok = $true }
+  # Active Directory (issue #82): the account's real domain. INTERACTIVE(2)
+  # covers policies that refuse NETWORK; CACHED_INTERACTIVE(11) validates
+  # against the local credential cache when no domain controller is reachable.
+  if (-not $ok -and $domainJoined) {
+    if ($api::LogonUser($u, $env:USERDOMAIN, $p, 3, 0, [ref]$tok)) { $ok = $true }
+    elseif ($api::LogonUser($u, $env:USERDOMAIN, $p, 2, 0, [ref]$tok)) { $ok = $true }
+    elseif ($api::LogonUser($u, $env:USERDOMAIN, $p, 11, 0, [ref]$tok)) { $ok = $true }
+  }
+  if (-not $ok -and $env:USERDNSDOMAIN) {
+    if ($api::LogonUser("$u@$env:USERDNSDOMAIN", $null, $p, 3, 0, [ref]$tok)) { $ok = $true }
+  }
+  if ($ok) { [void]$api::CloseHandle($tok); Write-Output 'TZ_OK'; exit 0 }
 } catch { }
 try {
   Add-Type -AssemblyName System.DirectoryServices.AccountManagement
@@ -110,9 +142,17 @@ try {
   $d = New-Object System.DirectoryServices.AccountManagement.PrincipalContext('Domain')
   if ($d.ValidateCredentials($u, $p)) { Write-Output 'TZ_OK'; exit 0 }
 } catch { }
-Write-Output 'TZ_FAIL'
+if ($domainJoined) { Write-Output 'TZ_FAIL_DOMAIN' } else { Write-Output 'TZ_FAIL' }
 exit 1
 `
+}
+
+function verifyWindows(username: string, password: string): Promise<OsAuthResult> {
+  return new Promise((resolve) => {
+    // Credentials ride env vars so they never appear in the process command
+    // line visible to other users. The verdict is printed as TZ_OK / TZ_FAIL /
+    // TZ_FAIL_DOMAIN.
+    const script = buildWindowsAuthScript()
     // PowerShell requires UTF-16LE base64 for -EncodedCommand.
     const encoded = Buffer.from(script, 'utf16le').toString('base64')
     const proc = spawn(
@@ -139,9 +179,16 @@ exit 1
         return
       }
       const detail = cleanPowerShellStderr(stderr)
+      // Domain-joined machine: "wrong password" is not the only explanation —
+      // every cached/online AD attempt failed, which also happens when the
+      // account can't be validated locally and no DC answers (issue #82).
+      const domainHint = stdout.includes('TZ_FAIL_DOMAIN')
+        ? ' — if your domain (Active Directory) password is correct, the domain controller may be unreachable; connect to the corporate network or VPN and try again'
+        : ''
       resolve({
         ok: false,
-        error: 'Incorrect system password' + (detail ? ` (${detail.slice(0, 200)})` : ''),
+        error:
+          'Incorrect system password' + domainHint + (detail ? ` (${detail.slice(0, 200)})` : ''),
       })
     })
   })

--- a/tests/main/os-auth-windows-ad.test.ts
+++ b/tests/main/os-auth-windows-ad.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue #82 — "Şifre Sıfırlama": a domain (Active Directory) account always
+ * failed OS-password verification. The script only tried domain '.' (local
+ * SAM) via LogonUser plus the two ValidateCredentials contexts; the Domain
+ * context throws when no DC is reachable, so a laptop off the corporate
+ * network/VPN reported "incorrect password" for a password Windows itself
+ * accepts through its credential cache.
+ *
+ * The LogonUser calls only run on Windows — what CAN be pinned here is the
+ * attempt chain inside the generated PowerShell program, so a refactor cannot
+ * silently drop an AD fallback again. Real AD verification is on the issue
+ * reporter's machine (stated in the issue comment).
+ */
+import { describe, it, expect } from 'vitest'
+import { buildWindowsAuthScript } from '../../src/main/lib/os-auth'
+
+describe('Windows OS-auth script — Active Directory chain (issue #82)', () => {
+  const script = buildWindowsAuthScript()
+
+  it('still tries the local SAM first (domain ".", NETWORK logon)', () => {
+    expect(script).toContain("LogonUser($u, '.', $p, 3, 0")
+  })
+
+  it("tries the account's real domain: NETWORK, INTERACTIVE, then CACHED_INTERACTIVE", () => {
+    expect(script).toContain('LogonUser($u, $env:USERDOMAIN, $p, 3, 0')
+    expect(script).toContain('LogonUser($u, $env:USERDOMAIN, $p, 2, 0')
+    // 11 = LOGON32_LOGON_CACHED_INTERACTIVE — validates against the local
+    // credential cache when the DC is unreachable (the VPN-off case).
+    expect(script).toContain('LogonUser($u, $env:USERDOMAIN, $p, 11, 0')
+  })
+
+  it('guards the domain attempts to actually domain-joined machines', () => {
+    expect(script).toContain('($env:USERDOMAIN) -and ($env:USERDOMAIN -ne $env:COMPUTERNAME)')
+  })
+
+  it('falls back to the UPN form when USERDNSDOMAIN is set', () => {
+    expect(script).toContain('LogonUser("$u@$env:USERDNSDOMAIN", $null, $p, 3, 0')
+  })
+
+  it('keeps both ValidateCredentials fallbacks (Machine, then Domain)', () => {
+    expect(script).toContain("PrincipalContext('Machine')")
+    expect(script).toContain("PrincipalContext('Domain')")
+  })
+
+  it('reports a domain-joined failure distinctly so the caller can hint at DC reachability', () => {
+    expect(script).toContain('TZ_FAIL_DOMAIN')
+    // The plain marker must survive too — non-domain machines keep the old verdict.
+    expect(script).toMatch(/Write-Output 'TZ_FAIL'/)
+  })
+})


### PR DESCRIPTION
Fix for issue #82 — password reset rejected a correct system password when the account is a domain (Active Directory) account.

## Root cause
The Windows verification chain only tried `LogonUser` against the **local SAM** (`domain '.'`) and then the two `ValidateCredentials` contexts. For an AD account the local attempt always fails, and `PrincipalContext('Domain')` **throws when no domain controller answers** — so a machine off the corporate network/VPN reported "Incorrect system password" for a password Windows itself accepts through its credential cache. All errors were silently swallowed, so the message never hinted at the real cause.

## Fix
The attempt chain now covers AD accounts (guarded to actually domain-joined machines, `USERDOMAIN != COMPUTERNAME`):

1. `LogonUser` local SAM, NETWORK — unchanged
2. `LogonUser` `USERDOMAIN`, NETWORK — AD with a reachable DC
3. `LogonUser` `USERDOMAIN`, INTERACTIVE — AD policies that refuse NETWORK logons
4. `LogonUser` `USERDOMAIN`, **CACHED_INTERACTIVE (11)** — validates against the same local credential cache the Windows lock screen uses when the DC is unreachable
5. `LogonUser` UPN form (`user@USERDNSDOMAIN`)
6. `PrincipalContext` Machine → Domain (existing fallbacks)

A failure on a domain-joined machine now prints `TZ_FAIL_DOMAIN`, and the error message adds "the domain controller may be unreachable; connect to the corporate network or VPN" instead of only claiming the password is wrong.

## Tests
The PowerShell program is extracted as `buildWindowsAuthScript()` and a new suite pins the full attempt chain (local-first order, the three domain logon types, the domain-joined guard, the UPN fallback, both `ValidateCredentials` contexts, and the distinct `TZ_FAIL_DOMAIN` marker). Full unit suite green (3512). The Windows-only execution itself can't run in CI/macOS — verification on a real AD machine is requested from the reporter on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)