### PR TITLE
Runner config persistence, new-tab dirty state, suite request picker + docs

### DIFF
--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -626,6 +626,7 @@ function runMigrations(database: Database.Database): void {
       name TEXT NOT NULL,
       description TEXT,
       sort_order INTEGER NOT NULL DEFAULT 0,
+      run_config TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
       FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
@@ -772,6 +773,10 @@ function runMigrations(database: Database.Database): void {
     `ALTER TABLE test_suite_folders ADD COLUMN auth TEXT`,
     `ALTER TABLE test_suite_folders ADD COLUMN pre_script TEXT`,
     `ALTER TABLE test_suite_folders ADD COLUMN post_script TEXT`,
+    // Per-suite Runner configuration (issue #100): sequence selection + roles,
+    // iterations/delays, stop-on-error, run lifecycle scripts — one opaque
+    // JSON blob owned by the renderer. NULL = never saved.
+    `ALTER TABLE test_suites ADD COLUMN run_config TEXT`,
     // Key Material Provider (#60) — keystore-backed client certificate rows.
     // Additive: existing installs get source='file' for every row, so the
     // classic crt/key/pfx path is untouched.

--- a/src/main/ipc/test-suite.handler.ts
+++ b/src/main/ipc/test-suite.handler.ts
@@ -532,6 +532,47 @@ export function registerTestSuiteHandlers(): void {
     }
   })
 
+  // ─── Run configuration (issue #100) ───────────────────────
+  // The Runner's per-suite run configuration — sequence selection + lifecycle
+  // roles, iterations/delays, stop-on-error, run hook scripts — stored as an
+  // opaque JSON string in `test_suites.run_config`. The renderer owns the
+  // shape (`SuiteRunConfig`); main just persists the blob so closing and
+  // reopening a suite restores the last saved setup. NULL = never saved.
+  ipcMain.handle('testSuite:getRunConfig', async (_event, suiteId: string) => {
+    try {
+      const db = getDb()
+      const row = db.prepare('SELECT run_config FROM test_suites WHERE id = ?').get(suiteId) as
+        | { run_config: string | null }
+        | undefined
+      if (!row) return { success: false, error: 'Test suite not found' }
+      return { success: true, data: row.run_config ?? null }
+    } catch (e) {
+      return { success: false, error: (e as Error).message }
+    }
+  })
+
+  ipcMain.handle(
+    'testSuite:saveRunConfig',
+    async (_event, suiteId: string, runConfig: string | null) => {
+      try {
+        if (runConfig !== null && typeof runConfig !== 'string') {
+          return { success: false, error: 'run config must be a JSON string or null' }
+        }
+        const db = getDb()
+        const exists = db.prepare('SELECT id FROM test_suites WHERE id = ?').get(suiteId)
+        if (!exists) return { success: false, error: 'Test suite not found' }
+        db.prepare('UPDATE test_suites SET run_config = ?, updated_at = ? WHERE id = ?').run(
+          runConfig,
+          Date.now(),
+          suiteId,
+        )
+        return { success: true, data: true }
+      } catch (e) {
+        return { success: false, error: (e as Error).message }
+      }
+    },
+  )
+
   // ─── Delete suite ─────────────────────────────────────────
   ipcMain.handle('testSuite:delete', async (_event, id: string) => {
     try {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1529,6 +1529,12 @@ interface TestSuiteApi {
     payload: ImportEndpointsPayload,
   ): Promise<IpcResult<{ added: number; rejected: number; rejectedIds: string[] }>>
   removeEndpoint(payload: RemoveEndpointPayload): Promise<IpcResult<boolean>>
+  /**
+   * Per-suite Runner configuration (issue #100). The payload is an opaque JSON
+   * string (renderer-owned `SuiteRunConfig` shape); null = never saved / clear.
+   */
+  getRunConfig(suiteId: string): Promise<IpcResult<string | null>>
+  saveRunConfig(suiteId: string, runConfig: string | null): Promise<IpcResult<boolean>>
 }
 
 interface CreateTestSuiteItemInput {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -401,6 +401,10 @@ const api = {
       ipcRenderer.invoke('testSuite:importEndpoints', payload),
     removeEndpoint: (payload: unknown): Promise<unknown> =>
       ipcRenderer.invoke('testSuite:removeEndpoint', payload),
+    getRunConfig: (suiteId: string): Promise<unknown> =>
+      ipcRenderer.invoke('testSuite:getRunConfig', suiteId),
+    saveRunConfig: (suiteId: string, runConfig: string | null): Promise<unknown> =>
+      ipcRenderer.invoke('testSuite:saveRunConfig', suiteId, runConfig),
   },
 
   // ─── Test Suite Items (inline request snapshots) ─────────────

--- a/src/renderer/components/layout/Workbench.tsx
+++ b/src/renderer/components/layout/Workbench.tsx
@@ -5,6 +5,7 @@ import { isMac } from '../../lib/platform'
 import { positionContextMenu, type MenuPosition } from '../../lib/menu-position'
 import { makeTabId } from '../../lib/utils'
 import { isBlankScratchTab } from '../../lib/tab-kind'
+import { isRequestLikeTab } from '../../lib/mark-dirty'
 import { openEndpointTab } from '../../lib/open-endpoint-tab'
 import UrlBar from './UrlBar'
 import UrlPreview from './UrlPreview'
@@ -482,9 +483,32 @@ function EndpointTabBar() {
     try {
       // `saveActiveRequestInPlace` targets the ACTIVE tab — make the closing tab
       // active first so a background tab's × still saves the right request.
-      if (useTabsStore.getState().activeTabId !== tabId) activateTab(tabId)
+      // `activateTab` only flips the protocol stores' live slices; it does NOT
+      // touch `tabs.activeTabId`, so without the explicit `setActiveTab` the
+      // save resolved the PREVIOUS active tab and wrote the closing tab's
+      // editor content into that tab's row (background-tab × corruption).
+      if (useTabsStore.getState().activeTabId !== tabId) {
+        activateTab(tabId)
+        useTabsStore.getState().setActiveTab(tabId)
+      }
       const result = await saveActiveRequestInPlace()
-      if (!result.success && !result.notApplicable) {
+      if (result.notApplicable) {
+        // Never-saved tab (New → HTTP etc.): there is no row to write in
+        // place. Route to the "Save As" modal — the same fallback Ctrl+S
+        // uses — and keep the tab OPEN: the modal's success path attaches
+        // the new savedRequestId and clears the dirty flag, after which a
+        // plain × closes without prompting. Previously this branch fell
+        // through to doCloseTab, so "Save & Close" on a new tab silently
+        // discarded the edits (issue #101).
+        setCloseSaving(false)
+        setCloseConfirmTabId(null)
+        const tab = useTabsStore.getState().tabs.find((t) => t.id === tabId)
+        if (tab && isRequestLikeTab(tab)) {
+          useUIStore.getState().setShowEndpointSaveModal(true)
+        }
+        return
+      }
+      if (!result.success) {
         toast.error(`Failed to save: ${result.error ?? 'unknown error'}`)
         setCloseSaving(false)
         return // keep the dialog open so the user can retry or cancel

--- a/src/renderer/components/modals/CreateSuiteFromFolderModal.tsx
+++ b/src/renderer/components/modals/CreateSuiteFromFolderModal.tsx
@@ -1,0 +1,227 @@
+import { useMemo, useState } from 'react'
+import { ListChecks } from 'lucide-react'
+import Modal from '../shared/Modal'
+import MethodBadge from '../shared/MethodBadge'
+import { t } from '../../lib/i18n'
+import { collectRequestIds, isRequestNode } from '../../lib/folder-request-selection'
+import type { TreeNode } from '../../types'
+
+interface CreateSuiteFromFolderModalProps {
+  open: boolean
+  /** The folder (or project root module) being turned into a suite. */
+  folder: TreeNode
+  /** Called with the selected request ids, in tree order. Never empty. */
+  onConfirm: (selectedIds: string[]) => void
+  onCancel: () => void
+}
+
+/** One subtree row — a request with a checkbox, or a folder that toggles its subtree. */
+function SelectionRow({
+  node,
+  depth,
+  selected,
+  onToggleRequest,
+  onToggleFolder,
+}: {
+  node: TreeNode
+  depth: number
+  selected: Set<string>
+  onToggleRequest: (id: string) => void
+  onToggleFolder: (node: TreeNode) => void
+}) {
+  const rowStyle = { paddingLeft: 8 + depth * 16, fontSize: 13, color: 'var(--text)' }
+  if (isRequestNode(node)) {
+    return (
+      <label className="flex cursor-pointer items-center gap-2 rounded py-1 pr-2" style={rowStyle}>
+        <input
+          type="checkbox"
+          data-testid={`suite-select-request-${node.id}`}
+          className="h-3.5 w-3.5 shrink-0 accent-[var(--accent)]"
+          checked={selected.has(node.id)}
+          onChange={() => onToggleRequest(node.id)}
+        />
+        {node.method && <MethodBadge method={node.method} small />}
+        <span className="min-w-0 flex-1 truncate">{node.label}</span>
+      </label>
+    )
+  }
+  const subtreeIds = collectRequestIds(node)
+  const allSelected = subtreeIds.length > 0 && subtreeIds.every((id) => selected.has(id))
+  const someSelected = subtreeIds.some((id) => selected.has(id))
+  return (
+    <>
+      <label className="flex cursor-pointer items-center gap-2 rounded py-1 pr-2" style={rowStyle}>
+        <input
+          type="checkbox"
+          data-testid={`suite-select-folder-${node.id}`}
+          className="h-3.5 w-3.5 shrink-0 accent-[var(--accent)]"
+          checked={allSelected}
+          // `indeterminate` is a DOM property, not an attribute.
+          ref={(el) => {
+            if (el) el.indeterminate = someSelected && !allSelected
+          }}
+          onChange={() => onToggleFolder(node)}
+        />
+        <span className="min-w-0 flex-1 truncate font-medium">{node.label}</span>
+      </label>
+      {(node.children ?? []).map((child) => (
+        <SelectionRow
+          key={child.id}
+          node={child}
+          depth={depth + 1}
+          selected={selected}
+          onToggleRequest={onToggleRequest}
+          onToggleFolder={onToggleFolder}
+        />
+      ))}
+    </>
+  )
+}
+
+/**
+ * Selection step between "Create Test Suite from this folder" and the actual
+ * create (issue #102). Everything starts selected so confirming straight away
+ * reproduces the old one-click full-folder behaviour; unchecking narrows the
+ * suite to a subset without post-create pruning.
+ */
+export default function CreateSuiteFromFolderModal({
+  open,
+  folder,
+  onConfirm,
+  onCancel,
+}: CreateSuiteFromFolderModalProps) {
+  const allIds = useMemo(() => collectRequestIds(folder), [folder])
+  // Mounted fresh per open (TreeView renders it conditionally), so the
+  // initializer is the reset — no effect needed.
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(collectRequestIds(folder)))
+
+  const toggleRequest = (id: string): void =>
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+
+  const toggleFolder = (node: TreeNode): void =>
+    setSelected((prev) => {
+      const ids = collectRequestIds(node)
+      const next = new Set(prev)
+      const all = ids.every((id) => next.has(id))
+      for (const id of ids) {
+        if (all) next.delete(id)
+        else next.add(id)
+      }
+      return next
+    })
+
+  const allChecked = selected.size === allIds.length
+  const toggleAll = (): void => setSelected(allChecked ? new Set() : new Set(allIds))
+  const count = t('suiteFromFolder.selectedCount')
+    .replace('{selected}', String(selected.size))
+    .replace('{total}', String(allIds.length))
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(o) => !o && onCancel()}
+      title={t('suiteFromFolder.title')}
+      testId="suite-select-modal"
+    >
+      <div
+        className="w-[460px] rounded-lg border shadow-xl"
+        style={{ background: 'var(--white)', borderColor: 'var(--border)' }}
+      >
+        {/* Header */}
+        <div
+          className="flex items-center gap-2.5 border-b px-5 py-4"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          <div
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full"
+            style={{ background: 'var(--accent-light)', border: '1px solid var(--accent)' }}
+          >
+            <ListChecks size={16} style={{ color: 'var(--accent-text)' }} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="truncate font-semibold" style={{ fontSize: 13, color: 'var(--text)' }}>
+              {t('suiteFromFolder.title')}: {folder.label}
+            </h3>
+            <p className="mt-0.5" style={{ fontSize: 12.5, color: 'var(--muted)' }}>
+              {t('suiteFromFolder.subtitle')}
+            </p>
+          </div>
+        </div>
+
+        {/* Toolbar: select all/none + counter */}
+        <div className="flex items-center justify-between px-5 pb-1 pt-3">
+          <button
+            type="button"
+            data-testid="suite-select-toggle-all"
+            onClick={toggleAll}
+            className="cursor-pointer rounded px-1 py-0.5 font-medium hover:opacity-80"
+            style={{ fontSize: 12.5, color: 'var(--accent-text)' }}
+          >
+            {allChecked ? t('suiteFromFolder.deselectAll') : t('suiteFromFolder.selectAll')}
+          </button>
+          <span data-testid="suite-select-count" style={{ fontSize: 12.5, color: 'var(--muted)' }}>
+            {count}
+          </span>
+        </div>
+
+        {/* Subtree with checkboxes */}
+        <div
+          className="mx-5 mb-4 mt-1 max-h-[320px] overflow-y-auto rounded-md border py-1"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          {(folder.children ?? []).map((child) => (
+            <SelectionRow
+              key={child.id}
+              node={child}
+              depth={0}
+              selected={selected}
+              onToggleRequest={toggleRequest}
+              onToggleFolder={toggleFolder}
+            />
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div
+          className="flex justify-end gap-2 border-t px-5 py-3"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          <button
+            type="button"
+            onClick={onCancel}
+            data-testid="suite-select-cancel"
+            className="cursor-pointer rounded-md border px-3.5 py-1.5 font-medium transition-colors hover:opacity-80"
+            style={{
+              fontSize: 13,
+              borderColor: 'var(--border)',
+              background: 'var(--white)',
+              color: 'var(--text)',
+            }}
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            data-testid="suite-select-confirm"
+            disabled={selected.size === 0}
+            onClick={() => onConfirm(allIds.filter((id) => selected.has(id)))}
+            className="rounded-md px-3.5 py-1.5 font-medium text-white transition-colors"
+            style={{
+              fontSize: 13,
+              background: 'var(--accent)',
+              cursor: selected.size === 0 ? 'not-allowed' : 'pointer',
+              opacity: selected.size === 0 ? 0.5 : 1,
+            }}
+          >
+            {t('suiteFromFolder.create')}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/renderer/components/runner/RunnerConfig.tsx
+++ b/src/renderer/components/runner/RunnerConfig.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useEnvironmentStore } from '../../stores/environment.store'
 import { useTranslation } from '../../lib/i18n'
 import { useNumberDraft } from '../../lib/number-draft'
+import { toast } from '../../lib/toast'
 
 type RunMode = 'manual' | 'schedule'
 type ScheduleType = 'interval' | 'daily' | 'weekly' | 'cron'
@@ -53,6 +54,12 @@ interface RunnerConfigProps {
   // path implies (Scheduled Tasks list, history-by-task, etc.) only ever
   // surfaces when the runner is actually wired to a suite.
   canSchedule?: boolean
+  /**
+   * Persist the run configuration to the suite (issue #100). Only provided
+   * for suite-scoped runs — APIs/folder runs have no suite row to save to,
+   * so the button is hidden there. Resolves true on success.
+   */
+  onSaveConfig?: () => Promise<boolean>
 }
 
 const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -85,8 +92,22 @@ export default function RunnerConfig({
   initialRunMode = 'manual',
   initialRunModeKey,
   canSchedule = true,
+  onSaveConfig,
 }: RunnerConfigProps) {
   const { t } = useTranslation()
+  const [isSavingConfig, setIsSavingConfig] = useState(false)
+
+  const handleSaveConfig = async () => {
+    if (!onSaveConfig || isSavingConfig) return
+    setIsSavingConfig(true)
+    try {
+      const ok = await onSaveConfig()
+      if (ok) toast.success(t('runnerConfig.saveConfigSaved'))
+      else toast.error(t('runnerConfig.saveConfigFailed'))
+    } finally {
+      setIsSavingConfig(false)
+    }
+  }
   const environments = useEnvironmentStore((s) => s.environments)
   // Same class the testers hit in the Password Generator: `Math.max(1, Number(''))`
   // is 1, so clearing the box instantly wrote the minimum back and the next digit
@@ -566,8 +587,8 @@ export default function RunnerConfig({
           />
         </div>
 
-        {/* Start run / Schedule */}
-        <div style={{ marginTop: 24 }}>
+        {/* Start run / Schedule + Save configuration (suite-scoped only, #100) */}
+        <div style={{ marginTop: 24, display: 'flex', alignItems: 'center', gap: 10 }}>
           <button
             type="button"
             data-testid="runner-start"
@@ -591,6 +612,19 @@ export default function RunnerConfig({
               <path d="M5 12l-2 2-2-2" />
             </svg>
           </button>
+          {onSaveConfig && (
+            <button
+              type="button"
+              data-testid="runner-save-config"
+              onClick={handleSaveConfig}
+              disabled={isSavingConfig}
+              title={t('runnerConfig.saveConfigHint')}
+              className="cursor-pointer rounded-[6px] border border-[var(--border)] bg-[var(--white)] px-4 py-2 font-semibold text-[var(--text)] hover:bg-[var(--bg)] disabled:cursor-not-allowed disabled:opacity-50"
+              style={{ fontSize: 13 }}
+            >
+              {t('runnerConfig.saveConfig')}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/components/runner/RunnerTab.tsx
+++ b/src/renderer/components/runner/RunnerTab.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react'
 import { buildExecutePayload, RUNNER_DEFAULTS } from '../../lib/runner-payload'
+import {
+  applyRunConfigToItems,
+  buildSuiteRunConfig,
+  parseSuiteRunConfig,
+} from '../../lib/suite-run-config'
+import type { SuiteRunConfig } from '../../types'
 import { Braces, ChevronRight } from 'lucide-react'
 import { useWorkspaceStore } from '../../stores/workspace.store'
 import { useEnvironmentStore } from '../../stores/environment.store'
@@ -507,6 +513,17 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
     return null
   })
 
+  /**
+   * Which suite's persisted run config has already been loaded into this tab
+   * (issue #100). The suite-items effect loads the config on its FIRST fetch
+   * per suite — one sequential async path, so saved options land in the same
+   * render batch as the endpoints and no load-order race exists. Event-driven
+   * refetches (`tests:suite-item-changed`) skip the config and merge the
+   * user's current in-session toggles instead. Reset by `handleNewRun` so
+   * re-picking a suite reloads its saved config.
+   */
+  const configLoadedForSuiteRef = useRef<string | null>(null)
+
   /*
    * The tab's opening instructions, split into two halves that live for
    * different lengths of time (issue #93).
@@ -809,6 +826,35 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
         folders: Array<{ id: string; name: string; parent_id?: string | null }>
       }
 
+      // Persisted per-suite run configuration (issue #100): loaded once per
+      // suite, on the first items fetch, so saved options reach their state in
+      // the same render batch as the endpoints themselves. A missing / corrupt
+      // config falls through to defaults — it must never block suite open.
+      let config: SuiteRunConfig | null = null
+      if (configLoadedForSuiteRef.current !== suiteIdForRunner) {
+        configLoadedForSuiteRef.current = suiteIdForRunner
+        try {
+          const cfgRes = await window.api?.testSuite?.getRunConfig?.(suiteIdForRunner)
+          if (cfgRes?.success) config = parseSuiteRunConfig(cfgRes.data)
+          else if (cfgRes) console.warn('runner: failed to load suite run config:', cfgRes.error)
+        } catch (err) {
+          console.warn('runner: failed to load suite run config:', (err as Error).message)
+        }
+        if (cancelled) return
+        if (config) {
+          setDelay(config.delay)
+          setIterationDelay(config.iterationDelay)
+          setIterations(config.iterations)
+          setStopOnError(config.stopOnError)
+          setPersistResponses(config.persistResponses)
+          setKeepVariableValues(config.keepVariableValues)
+          setEnvironmentId(config.environmentId ?? '')
+          setRunPreScript(config.runPreScript ?? '')
+          setRunPostScript(config.runPostScript ?? '')
+        }
+      }
+      const savedConfig = config
+
       const toRunnerItem = (it: (typeof items)[number]): RunnerEndpointItem => ({
         id: it.id,
         name: it.name,
@@ -817,7 +863,25 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
         selected: true,
       })
 
-      setEndpoints(items.map(toRunnerItem))
+      /**
+       * selected/phase for the freshly fetched rows. Refetches (rename /
+       * reorder events) MERGE the user's current in-session state — before
+       * this, any drag-reorder rebuilt the list with everything re-selected
+       * and every lifecycle role dropped. On the first load per suite the
+       * saved config is applied on top (prev state is empty then anyway).
+       */
+      const decorate = (built: RunnerEndpointItem[], prevById: Map<string, RunnerEndpointItem>) => {
+        let next = built.map((it) => {
+          const p = prevById.get(it.id)
+          return p ? { ...it, selected: p.selected, phase: p.phase } : it
+        })
+        if (savedConfig) next = applyRunConfigToItems(next, savedConfig)
+        return next
+      }
+
+      setEndpoints((prev) =>
+        decorate(items.map(toRunnerItem), new Map(prev.map((ep) => [ep.id, ep]))),
+      )
 
       if (folders.length > 0) {
         // One group per suite folder — including empty ones, so a nested
@@ -838,19 +902,32 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
           }
           return parts.join(' / ')
         }
-        const groups: RunnerFolderGroup[] = folders.map((f) => ({
-          folderId: f.id,
-          folderName: pathOf(f.id),
-          label: f.name,
-          parentId: f.parent_id ?? null,
-          endpoints: [],
-        }))
-        const groupById = new Map(groups.map((g) => [g.folderId, g]))
-        for (const it of items) {
-          if (!it.folder_id) continue
-          groupById.get(it.folder_id)?.endpoints.push(toRunnerItem(it))
-        }
-        setFolderGroups(groups)
+        // Functional updater for the same reason as `setEndpoints` above: the
+        // previous groups carry the user's in-session selected/phase state and
+        // must survive an event-driven refetch. Group construction is pure, so
+        // rebuilding inside the updater is double-invoke safe.
+        setFolderGroups((prevGroups) => {
+          const prevById = new Map<string, RunnerEndpointItem>()
+          for (const g of prevGroups) {
+            for (const ep of g.endpoints) prevById.set(ep.id, ep)
+          }
+          const groups: RunnerFolderGroup[] = folders.map((f) => ({
+            folderId: f.id,
+            folderName: pathOf(f.id),
+            label: f.name,
+            parentId: f.parent_id ?? null,
+            endpoints: [],
+          }))
+          const groupById = new Map(groups.map((g) => [g.folderId, g]))
+          for (const it of items) {
+            if (!it.folder_id) continue
+            groupById.get(it.folder_id)?.endpoints.push(toRunnerItem(it))
+          }
+          for (const g of groups) {
+            g.endpoints = decorate(g.endpoints, prevById)
+          }
+          return groups
+        })
       } else {
         setFolderGroups([])
       }
@@ -1157,6 +1234,9 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
     setSuiteIdForRunner(null)
     setRunOrigin('runner')
     setRunFolderName('')
+    // Scope cleared → forget which suite's saved run config was loaded, so
+    // re-picking a suite (even the same one) reloads it from the DB.
+    configLoadedForSuiteRef.current = null
   }, [])
 
   const handleViewAllRuns = useCallback(() => {
@@ -1239,6 +1319,55 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
       runPostScript,
     ],
   )
+
+  /**
+   * Persist the current run configuration to the suite (issue #100) —
+   * sequence selection + lifecycle roles, run options, environment, and the
+   * run hook scripts. EXPLICIT save on purpose: the auto-run path rewrites
+   * `selected` programmatically (sidebar "Run Suite" targets specific ids),
+   * so auto-saving would silently clobber a curated config on every quick
+   * run. Returns success so RunnerConfig can toast in the user's language.
+   */
+  const handleSaveConfig = useCallback(async (): Promise<boolean> => {
+    if (!suiteIdForRunner) return false
+    const config = buildSuiteRunConfig(endpoints, {
+      delay,
+      iterationDelay,
+      iterations,
+      stopOnError,
+      persistResponses,
+      keepVariableValues,
+      environmentId,
+      runPreScript,
+      runPostScript,
+    })
+    try {
+      const res = await window.api?.testSuite?.saveRunConfig?.(
+        suiteIdForRunner,
+        JSON.stringify(config),
+      )
+      if (!res?.success) {
+        console.warn('runner: failed to save suite run config:', res?.error)
+        return false
+      }
+      return true
+    } catch (err) {
+      console.warn('runner: failed to save suite run config:', (err as Error).message)
+      return false
+    }
+  }, [
+    suiteIdForRunner,
+    endpoints,
+    delay,
+    iterationDelay,
+    iterations,
+    stopOnError,
+    persistResponses,
+    keepVariableValues,
+    environmentId,
+    runPreScript,
+    runPostScript,
+  ])
 
   const handleSequenceResize = useCallback((dx: number) => {
     setSequenceWidth((w) => Math.max(200, Math.min(600, w + dx)))
@@ -1336,6 +1465,9 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
                 // one-shots; hiding the Schedule radio prevents stranded
                 // "Scheduled: ad-hoc" tasks that no one knows where to find.
                 canSchedule={!!suiteIdForRunner}
+                // Saving a run configuration also lives on Test Suites — an
+                // APIs / folder run has no suite row to store it on (#100).
+                onSaveConfig={suiteIdForRunner ? handleSaveConfig : undefined}
               />
             </div>
           </>

--- a/src/renderer/components/sidebar/TreeView.tsx
+++ b/src/renderer/components/sidebar/TreeView.tsx
@@ -18,6 +18,8 @@ import type {
 import TreeNodeComponent, { type DragPayload, type DropPosition } from './TreeNode'
 import DeleteConfirmDialog from '../modals/DeleteConfirmDialog'
 import FolderSettingsModal from '../modals/FolderSettingsModal'
+import CreateSuiteFromFolderModal from '../modals/CreateSuiteFromFolderModal'
+import { collectRequestIds } from '../../lib/folder-request-selection'
 import { toast } from '../../lib/toast'
 import { t } from '../../lib/i18n'
 import { openFolderRunner } from '../../lib/open-runner-tab'
@@ -495,6 +497,8 @@ export default function TreeView() {
 
   // Delete confirmation dialog state
   const [deleteTarget, setDeleteTarget] = useState<TreeNode | null>(null)
+  // Folder/project → test suite request-selection modal (issue #102)
+  const [suiteSelectTarget, setSuiteSelectTarget] = useState<TreeNode | null>(null)
   const [folderSettingsTarget, setFolderSettingsTarget] = useState<{
     id: string
     name: string
@@ -844,15 +848,10 @@ export default function TreeView() {
    * descendants in nested sub-folders. Operates on the in-memory tree so we
    * don't need a new IPC for "list endpoints recursively" (UX 6).
    */
-  const collectRequestIdsRecursive = useCallback((folderNode: TreeNode): string[] => {
-    const ids: string[] = []
-    function walk(n: TreeNode): void {
-      if (n.type === 'endpoint' || n.type === 'request') ids.push(n.id)
-      if (n.children) for (const c of n.children) walk(c)
-    }
-    walk(folderNode)
-    return ids
-  }, [])
+  const collectRequestIdsRecursive = useCallback(
+    (folderNode: TreeNode): string[] => collectRequestIds(folderNode),
+    [],
+  )
 
   const setActiveSidebarPage = (() => {
     // Late-import via dynamic require so we don't pull the store at module top
@@ -876,15 +875,13 @@ export default function TreeView() {
    * `rejected` matters as much as the failures: a suite built from 40 requests
    * that copied 37 is not a success, and reporting it as one is how a run comes
    * up short later for no visible reason.
+   *
+   * Shared by the direct single-request path and the selection modal's confirm
+   * (#102) — `ids` is the (possibly user-narrowed) request set to copy.
    */
-  const handleCreateTestSuite = useCallback(
-    async (folderNode: TreeNode) => {
-      if (!activeProjectId) return
-      const ids = collectRequestIdsRecursive(folderNode)
-      if (ids.length === 0) {
-        toast.info(t('tree.suiteEmptyFolder'))
-        return
-      }
+  const performCreateTestSuite = useCallback(
+    async (folderNode: TreeNode, ids: string[]) => {
+      if (!activeProjectId || ids.length === 0) return
       try {
         const createRes = (await window.api?.testSuite?.create({
           project_id: activeProjectId,
@@ -923,7 +920,30 @@ export default function TreeView() {
         toast.error(`${t('tree.suiteCreateFailed')}: ${(err as Error).message || 'unknown error'}`)
       }
     },
-    [activeProjectId, collectRequestIdsRecursive],
+    [activeProjectId],
+  )
+
+  /**
+   * Entry point for the three context-menu items. A single request has nothing
+   * to choose from, so it creates directly; folders and the project root get a
+   * selection step first — the old behaviour copied EVERY request under the
+   * folder into the suite, and a subset required post-create pruning (#102).
+   */
+  const handleCreateTestSuite = useCallback(
+    (folderNode: TreeNode) => {
+      if (!activeProjectId) return
+      const ids = collectRequestIdsRecursive(folderNode)
+      if (ids.length === 0) {
+        toast.info(t('tree.suiteEmptyFolder'))
+        return
+      }
+      if (folderNode.type === 'folder' || folderNode.type === 'module') {
+        setSuiteSelectTarget(folderNode)
+        return
+      }
+      void performCreateTestSuite(folderNode, ids)
+    },
+    [activeProjectId, collectRequestIdsRecursive, performCreateTestSuite],
   )
 
   /**
@@ -1126,6 +1146,21 @@ export default function TreeView() {
           folderId={folderSettingsTarget.id}
           folderName={folderSettingsTarget.name}
           onClose={() => setFolderSettingsTarget(null)}
+        />
+      )}
+
+      {/* Folder/project → test suite request selection (issue #102). Mounted
+          per open so the modal's "all selected" default resets every time. */}
+      {suiteSelectTarget && (
+        <CreateSuiteFromFolderModal
+          open
+          folder={suiteSelectTarget}
+          onConfirm={(ids) => {
+            const target = suiteSelectTarget
+            setSuiteSelectTarget(null)
+            void performCreateTestSuite(target, ids)
+          }}
+          onCancel={() => setSuiteSelectTarget(null)}
         />
       )}
 

--- a/src/renderer/lib/folder-request-selection.ts
+++ b/src/renderer/lib/folder-request-selection.ts
@@ -1,0 +1,25 @@
+import type { TreeNode } from '../types'
+
+/** True for nodes that represent a runnable request (saved request or imported endpoint). */
+export function isRequestNode(node: TreeNode): boolean {
+  return node.type === 'endpoint' || node.type === 'request'
+}
+
+/**
+ * Recursively gather every request/endpoint id under a node — including the
+ * node itself when it is a request — in tree (depth-first) order. Operates on
+ * the in-memory tree so no "list endpoints recursively" IPC is needed (UX 6).
+ *
+ * Shared by TreeView's folder→suite / folder→mock flows and the request
+ * selection modal (issue #102), so "which requests live under this folder"
+ * has one answer everywhere.
+ */
+export function collectRequestIds(node: TreeNode): string[] {
+  const ids: string[] = []
+  const walk = (n: TreeNode): void => {
+    if (isRequestNode(n)) ids.push(n.id)
+    if (n.children) for (const c of n.children) walk(c)
+  }
+  walk(node)
+  return ids
+}

--- a/src/renderer/lib/i18n.ts
+++ b/src/renderer/lib/i18n.ts
@@ -216,6 +216,13 @@ const translations: Record<Locale, Record<string, string>> = {
     'tree.suiteCreated': 'Test suite created',
     'tree.suiteCreateFailed': 'Could not create the test suite',
     'tree.suiteImportPartial': 'Some requests could not be copied into the suite',
+    'suiteFromFolder.title': 'Create Test Suite',
+    'suiteFromFolder.subtitle':
+      'Choose which requests go into the suite. Subfolders keep their structure.',
+    'suiteFromFolder.selectAll': 'Select all',
+    'suiteFromFolder.deselectAll': 'Deselect all',
+    'suiteFromFolder.selectedCount': '{selected}/{total} selected',
+    'suiteFromFolder.create': 'Create Suite',
     'tree.createMockServer': 'Create Mock Server from this folder',
     'tree.createMockServerFromProject': 'Create Mock Server from this project',
     'tree.createMockServerFromRequest': 'Create Mock Server from this request',
@@ -943,6 +950,12 @@ const translations: Record<Locale, Record<string, string>> = {
     'runnerVars.noGlobals': 'No global variables in this workspace.',
     'runnerVars.add': 'Add',
     'runnerVars.selectEnv': 'Select an environment to see its variables.',
+
+    // Suite run configuration persistence (issue #100)
+    'runnerConfig.saveConfig': 'Save configuration',
+    'runnerConfig.saveConfigHint': 'Saved to this suite — restored the next time you open it.',
+    'runnerConfig.saveConfigSaved': 'Run configuration saved',
+    'runnerConfig.saveConfigFailed': 'Failed to save run configuration',
 
     // Run lifecycle — setup / teardown phases (issue #72)
     'runPhase.main': 'Flow',
@@ -2407,6 +2420,12 @@ const translations: Record<Locale, Record<string, string>> = {
     'tree.suiteCreated': 'Test suite oluşturuldu',
     'tree.suiteCreateFailed': 'Test suite oluşturulamadı',
     'tree.suiteImportPartial': 'Bazı istekler suite’e kopyalanamadı',
+    'suiteFromFolder.title': 'Test Suite Oluştur',
+    'suiteFromFolder.subtitle': 'Suite’e girecek istekleri seç. Alt klasör yapısı korunur.',
+    'suiteFromFolder.selectAll': 'Tümünü seç',
+    'suiteFromFolder.deselectAll': 'Tümünü bırak',
+    'suiteFromFolder.selectedCount': '{selected}/{total} seçili',
+    'suiteFromFolder.create': 'Suite Oluştur',
     'tree.createMockServer': 'Bu klasörden Mock Sunucu oluştur',
     'tree.createMockServerFromProject': 'Bu projeden Mock Sunucu oluştur',
     'tree.createMockServerFromRequest': 'Bu istekten Mock Sunucu oluştur',
@@ -3135,6 +3154,12 @@ const translations: Record<Locale, Record<string, string>> = {
     'runnerVars.noGlobals': 'Bu çalışma alanında global değişken yok.',
     'runnerVars.add': 'Ekle',
     'runnerVars.selectEnv': 'Değişkenleri görmek için bir ortam seçin.',
+
+    // Suite çalıştırma yapılandırması kalıcılığı (issue #100)
+    'runnerConfig.saveConfig': 'Yapılandırmayı kaydet',
+    'runnerConfig.saveConfigHint': 'Bu suite’e kaydedilir — bir sonraki açılışta geri yüklenir.',
+    'runnerConfig.saveConfigSaved': 'Çalıştırma yapılandırması kaydedildi',
+    'runnerConfig.saveConfigFailed': 'Çalıştırma yapılandırması kaydedilemedi',
 
     // Çalıştırma yaşam döngüsü — setup / teardown fazları (issue #72)
     'runPhase.main': 'Akış',

--- a/src/renderer/lib/keyboard-shortcuts.ts
+++ b/src/renderer/lib/keyboard-shortcuts.ts
@@ -8,7 +8,7 @@ import { useUIStore } from '../stores/ui.store'
 import { useWorkspaceStore } from '../stores/workspace.store'
 import { isMac } from './platform'
 import { makeTabId } from './utils'
-import { isToolProtocol } from '../types'
+import { isRequestLikeTab } from './mark-dirty'
 import { saveActiveRequestInPlace } from './save-active-request'
 import { toast } from './toast'
 
@@ -84,19 +84,14 @@ export function useKeyboardShortcuts(): void {
             const tabs = useTabsStore.getState()
             const active = tabs.tabs.find((t) => t.id === tabs.activeTabId)
             // A tab is a request tab if (a) it carries one of the resource ids
-            // — endpoint / saved request / mock / test suite item — or (b) its
+            // — endpoint / saved request / test suite item — or (b) its
             // protocol is a regular request protocol. Without the id-based
             // check, freshly-opened "New Request" tabs whose protocol field
             // hadn't propagated yet fell through to the project-save branch
-            // (v1.3.1 M8).
-            const isRequestTab =
-              !!active &&
-              (!!active.endpointId ||
-                !!active.savedRequestId ||
-                !!active.testSuiteItemId ||
-                (!isToolProtocol(active.protocol) &&
-                  active.protocol !== 'runner' &&
-                  active.protocol !== 'mockServer'))
+            // (v1.3.1 M8). The predicate is shared with the dirty-dot logic
+            // (`mark-dirty.ts`, issue #101) so Ctrl+S routing and the unsaved
+            // indicator can never disagree about what counts as a request tab.
+            const isRequestTab = !!active && isRequestLikeTab(active)
             if (!isRequestTab) {
               ui.setShowSaveModal(true)
               return

--- a/src/renderer/lib/mark-dirty.ts
+++ b/src/renderer/lib/mark-dirty.ts
@@ -1,4 +1,28 @@
 import { useTabsStore } from '../stores/tabs.store'
+import { isToolProtocol } from '../types'
+import type { Tab } from '../types'
+
+/**
+ * Can this tab hold unsaved request edits at all?
+ *
+ * True for any tab backed by a persisted row (endpoint / saved request /
+ * test-suite item — those have an in-place save path), and for scratch tabs
+ * whose protocol is a regular request protocol (http, soap, websocket,
+ * graphql, grpc, sse, ai, mcp, socketio — those save via the "Save As"
+ * EndpointSaveModal). False for Tools tabs, the Runner tab and the Mock
+ * Server editor: they carry no request to be dirty against (the mock editor
+ * has its own save flow).
+ *
+ * Shared with the Ctrl+S handler in `keyboard-shortcuts.ts` — keep ONE
+ * request-tab predicate so the dirty dot, the close confirm and the save
+ * routing can never disagree about what counts as a request tab.
+ */
+export function isRequestLikeTab(
+  tab: Pick<Tab, 'protocol' | 'endpointId' | 'savedRequestId' | 'testSuiteItemId'>,
+): boolean {
+  if (tab.endpointId || tab.savedRequestId || tab.testSuiteItemId) return true
+  return !isToolProtocol(tab.protocol) && tab.protocol !== 'runner' && tab.protocol !== 'mockServer'
+}
 
 /**
  * Flag the active tab as having unsaved changes (the blue dirty dot in the tab
@@ -7,9 +31,11 @@ import { useTabsStore } from '../stores/tabs.store'
  * HTTP editor was wired in, so SOAP / WebSocket / Socket.IO / GraphQL / gRPC /
  * SSE edits showed no unsaved-change signal (issue #8).
  *
- * Gated on the active tab being backed by a saved request / endpoint: a scratch
- * tab with no backing row has nothing to be "dirty" against, matching the HTTP
- * store's original behaviour.
+ * Applies to every request-like tab, INCLUDING brand-new tabs with no backing
+ * row yet (New → HTTP etc.). The old gate — "only endpoint / saved-request
+ * backed tabs" — meant a fresh tab could never turn dirty, so closing it
+ * silently discarded the edits with no dot and no confirm dialog (issue #101).
+ * Non-request tabs (Tools / Runner / Mock Server) are still never flagged.
  *
  * Lives in lib/ (not request.store) so the protocol stores can import it without
  * pulling in the whole request store — it only depends on the tabs store.
@@ -18,7 +44,7 @@ export function markActiveTabDirty(): void {
   const { activeTabId, tabs, markDirty } = useTabsStore.getState()
   if (!activeTabId) return
   const tab = tabs.find((t) => t.id === activeTabId)
-  if (tab?.endpointId || tab?.savedRequestId) {
+  if (tab && isRequestLikeTab(tab)) {
     markDirty(activeTabId, true)
   }
 }

--- a/src/renderer/lib/suite-run-config.ts
+++ b/src/renderer/lib/suite-run-config.ts
@@ -1,0 +1,159 @@
+/**
+ * Per-suite Runner run configuration — pure serialise / parse / apply helpers
+ * (issue #100).
+ *
+ * The Runner's sequence selection (include/exclude + setup/flow/teardown
+ * roles) and its run options (iterations, delays, stop-on-error, lifecycle
+ * scripts, environment) used to live only in RunnerTab React state plus
+ * tab-scoped sessionStorage, so closing the suite's tab discarded the whole
+ * setup. The config is now saved SUITE-scoped: serialised by
+ * `buildSuiteRunConfig`, stored via `testSuite:saveRunConfig` as one JSON blob
+ * in `test_suites.run_config`, and restored on suite open through
+ * `parseSuiteRunConfig` + `applyRunConfigToItems`.
+ *
+ * Everything here is pure TS so the load/apply logic is unit-testable without
+ * mounting RunnerTab (tests/renderer/suite-run-config.test.ts).
+ *
+ * Deliberately NOT part of the config (see `SuiteRunConfig` docs in types):
+ * sequence order (already suite-persistent via `test_suite_items.sort_order`)
+ * and iteration data files (file-derived, potentially MB-scale).
+ */
+import type { SuiteRunConfig, SuiteRunConfigItem } from '../types'
+
+type Phase = 'setup' | 'main' | 'teardown'
+
+/** The minimal structural shape of a sequence row this module needs. */
+export interface SequenceItemLike {
+  id: string
+  selected: boolean
+  phase?: Phase
+}
+
+/** Run options half of the config — mirrors RunnerTab's option state. */
+export interface SuiteRunOptions {
+  delay: number
+  iterationDelay: number
+  iterations: number
+  stopOnError: boolean
+  persistResponses: boolean
+  keepVariableValues: boolean
+  environmentId: string
+  runPreScript: string
+  runPostScript: string
+}
+
+/**
+ * Build the serialisable config from the runner tab's current state.
+ * Flow items store no `phase` (omitted = 'main'), and blank optional strings
+ * are omitted entirely so the stored blob stays minimal and diff-friendly.
+ */
+export function buildSuiteRunConfig(
+  items: readonly SequenceItemLike[],
+  options: SuiteRunOptions,
+): SuiteRunConfig {
+  const configItems: SuiteRunConfigItem[] = items.map((it) => {
+    const entry: SuiteRunConfigItem = { id: it.id, selected: it.selected }
+    if (it.phase && it.phase !== 'main') entry.phase = it.phase
+    return entry
+  })
+  const config: SuiteRunConfig = {
+    version: 1,
+    items: configItems,
+    delay: options.delay,
+    iterationDelay: options.iterationDelay,
+    iterations: options.iterations,
+    stopOnError: options.stopOnError,
+    persistResponses: options.persistResponses,
+    keepVariableValues: options.keepVariableValues,
+  }
+  if (options.environmentId.trim()) config.environmentId = options.environmentId
+  if (options.runPreScript.trim()) config.runPreScript = options.runPreScript
+  if (options.runPostScript.trim()) config.runPostScript = options.runPostScript
+  return config
+}
+
+const PHASES: readonly Phase[] = ['setup', 'main', 'teardown']
+
+function sanitiseNumber(value: unknown, fallback: number, min: number): number {
+  const n = typeof value === 'number' ? value : Number.NaN
+  if (!Number.isFinite(n) || n < min) return fallback
+  return n
+}
+
+function sanitiseBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+/**
+ * Parse a stored `run_config` blob into a `SuiteRunConfig`, tolerantly.
+ *
+ * A corrupt or unparseable blob must NEVER block opening the suite — the
+ * caller falls back to defaults (all selected, RUNNER_DEFAULTS options), the
+ * same state a suite without a saved config gets. Malformed item entries are
+ * dropped individually; out-of-range numbers snap to the defaults.
+ */
+export function parseSuiteRunConfig(raw: string | null | undefined): SuiteRunConfig | null {
+  if (!raw) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+  const obj = parsed as Record<string, unknown>
+  if (!Array.isArray(obj.items)) return null
+
+  const items: SuiteRunConfigItem[] = []
+  for (const entry of obj.items) {
+    if (!entry || typeof entry !== 'object') continue
+    const e = entry as Record<string, unknown>
+    if (typeof e.id !== 'string' || !e.id) continue
+    const item: SuiteRunConfigItem = { id: e.id, selected: e.selected !== false }
+    if (typeof e.phase === 'string' && PHASES.includes(e.phase as Phase) && e.phase !== 'main') {
+      item.phase = e.phase as Phase
+    }
+    items.push(item)
+  }
+
+  const config: SuiteRunConfig = {
+    version: 1,
+    items,
+    delay: sanitiseNumber(obj.delay, 0, 0),
+    iterationDelay: sanitiseNumber(obj.iterationDelay, 0, 0),
+    iterations: sanitiseNumber(obj.iterations, 1, 1),
+    stopOnError: sanitiseBoolean(obj.stopOnError, true),
+    persistResponses: sanitiseBoolean(obj.persistResponses, true),
+    keepVariableValues: sanitiseBoolean(obj.keepVariableValues, true),
+  }
+  if (typeof obj.environmentId === 'string' && obj.environmentId) {
+    config.environmentId = obj.environmentId
+  }
+  if (typeof obj.runPreScript === 'string' && obj.runPreScript) {
+    config.runPreScript = obj.runPreScript
+  }
+  if (typeof obj.runPostScript === 'string' && obj.runPostScript) {
+    config.runPostScript = obj.runPostScript
+  }
+  return config
+}
+
+/**
+ * Apply a saved config's per-item state onto a freshly fetched sequence.
+ *
+ * Matching is by suite item id. Items the config does not know (added after
+ * the save) keep their defaults; config entries whose item no longer exists
+ * are ignored — deleting a request must not resurrect it or break the load.
+ * Returns new objects; never mutates the input.
+ */
+export function applyRunConfigToItems<T extends SequenceItemLike>(
+  items: readonly T[],
+  config: SuiteRunConfig,
+): T[] {
+  const byId = new Map(config.items.map((c) => [c.id, c]))
+  return items.map((it) => {
+    const saved = byId.get(it.id)
+    if (!saved) return { ...it }
+    return { ...it, selected: saved.selected, phase: saved.phase }
+  })
+}

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -1268,6 +1268,8 @@ export interface TestSuiteRow {
   name: string
   description: string | null
   sort_order: number
+  /** Persisted Runner configuration (issue #100) — JSON `SuiteRunConfig`; null = never saved. */
+  run_config?: string | null
   created_at: number
   updated_at: number
 }
@@ -1299,6 +1301,40 @@ export interface TestSuiteFolderRow {
 export interface TestSuiteContents {
   items: TestSuiteItemRow[]
   folders: TestSuiteFolderRow[]
+}
+
+/**
+ * Persisted Runner run configuration for a test suite (issue #100).
+ *
+ * Serialised to JSON and stored opaquely in `test_suites.run_config`;
+ * parse/build/apply helpers live in `src/renderer/lib/suite-run-config.ts`.
+ * Sequence ORDER is deliberately absent — it already persists in
+ * `test_suite_items.sort_order` (drag-reorder goes through the move IPC), and
+ * duplicating it here would create a second source of truth. `iterationData`
+ * (CSV/JSON data files) is also excluded: it is file-derived and potentially
+ * MB-scale — like Postman, the user re-picks the data file per session.
+ */
+export interface SuiteRunConfigItem {
+  /** `test_suite_items.id` the entry applies to. */
+  id: string
+  selected: boolean
+  /** Lifecycle role — structurally identical to shared `RunPhase`. Omitted = 'main'. */
+  phase?: 'setup' | 'main' | 'teardown'
+}
+
+export interface SuiteRunConfig {
+  version: 1
+  /** Per-item selection + lifecycle role, keyed by suite item id. */
+  items: SuiteRunConfigItem[]
+  delay: number
+  iterationDelay: number
+  iterations: number
+  stopOnError: boolean
+  persistResponses: boolean
+  keepVariableValues: boolean
+  environmentId?: string
+  runPreScript?: string
+  runPostScript?: string
 }
 
 export type MockServerStatus = 'stopped' | 'starting' | 'running' | 'error'

--- a/tests/e2e/ui/35-tester-findings-aug07.spec.ts
+++ b/tests/e2e/ui/35-tester-findings-aug07.spec.ts
@@ -125,6 +125,9 @@ uiTest.describe('tester findings, 7 August', () => {
     await navigateSidebar(window, 'apis')
     await treeOpenNode(window, root)
     await treeContextAction(window, root, /Create Test Suite from this folder/i)
+    // #102: a request-selection step now sits between the menu item and the
+    // create — confirming the default (everything selected) keeps this flow.
+    await window.getByTestId('suite-select-confirm').click()
 
     // It hands off to Tests. The suite is named after the folder.
     await navigateSidebar(window, 'tests')
@@ -163,6 +166,8 @@ uiTest.describe('tester findings, 7 August', () => {
       await navigateSidebar(window, 'apis')
       await treeOpenNode(window, root)
       await treeContextAction(window, root, /Create Test Suite from this folder/i)
+      // #102: confirm the selection modal's all-selected default.
+      await window.getByTestId('suite-select-confirm').click()
 
       await navigateSidebar(window, 'tests')
       await expect(suiteRow(window, root)).toBeVisible({ timeout: 20_000 })

--- a/tests/main/handlers/helpers.ts
+++ b/tests/main/handlers/helpers.ts
@@ -453,6 +453,7 @@ const SCHEMA_SQL = `
     name TEXT NOT NULL,
     description TEXT,
     sort_order INTEGER NOT NULL DEFAULT 0,
+    run_config TEXT,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
   );

--- a/tests/main/handlers/test-suite-run-config.test.ts
+++ b/tests/main/handlers/test-suite-run-config.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Issue #100 — persisted Runner run configuration per test suite.
+ *
+ * The Runner's Run Sequence (include/exclude + setup/flow/teardown roles) and
+ * run options (iterations, delays, stop-on-error, lifecycle scripts) used to
+ * live only in RunnerTab React state + tab-scoped sessionStorage, so closing
+ * the suite tab lost the whole configuration. These tests drive the new
+ * `testSuite:getRunConfig` / `testSuite:saveRunConfig` IPC pair over the real
+ * handler + a real SQLite test DB:
+ *
+ *  - save → get round-trip returns the exact JSON string
+ *  - a fresh suite has no config (null)
+ *  - saving null clears a stored config
+ *  - unknown suite ids fail cleanly on both channels
+ *  - deleting the suite removes the config with the row
+ *  - duplicating a suite deliberately does NOT copy run_config (item ids are
+ *    reminted on duplicate, so a verbatim copy would reference dead ids)
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  setupHandlerHarness,
+  makeElectronMock,
+  createTestDb,
+  seedProject,
+  seedWorkspace,
+} from './helpers'
+import crypto from 'node:crypto'
+import type Database from 'better-sqlite3'
+
+const harness = setupHandlerHarness()
+vi.mock('electron', () => ({ ...makeElectronMock() }))
+
+let testDb: ReturnType<typeof createTestDb>
+vi.mock('../../../src/main/db/database', () => ({ getDb: () => testDb }))
+
+const { registerTestSuiteHandlers } = await import('../../../src/main/ipc/test-suite.handler')
+
+let projectId: string
+let suiteId: string
+
+type ConfigRes = { success: boolean; data?: string | null; error?: string }
+type SaveRes = { success: boolean; data?: boolean; error?: string }
+type SuiteRes = { success: boolean; data?: { id: string }; error?: string }
+
+function seedSuite(db: Database.Database, project: string): string {
+  const now = Date.now()
+  const suite = crypto.randomUUID()
+  db.prepare(
+    `INSERT INTO test_suites (id, project_id, name, sort_order, created_at, updated_at)
+     VALUES (?, ?, 'Suite', 0, ?, ?)`,
+  ).run(suite, project, now, now)
+  return suite
+}
+
+const getConfig = (id: string): Promise<ConfigRes> =>
+  harness.invoke('testSuite:getRunConfig', id) as Promise<ConfigRes>
+
+const saveConfig = (id: string, config: string | null): Promise<SaveRes> =>
+  harness.invoke('testSuite:saveRunConfig', id, config) as Promise<SaveRes>
+
+const SAMPLE_CONFIG = JSON.stringify({
+  version: 1,
+  items: [
+    { id: 'item-1', selected: true, phase: 'setup' },
+    { id: 'item-2', selected: false },
+    { id: 'item-3', selected: true, phase: 'teardown' },
+  ],
+  delay: 250,
+  iterationDelay: 1000,
+  iterations: 3,
+  stopOnError: false,
+  persistResponses: true,
+  keepVariableValues: false,
+  environmentId: 'env-9',
+  runPreScript: 'console.log("pre")',
+  runPostScript: 'console.log("post")',
+})
+
+beforeEach(() => {
+  harness.reset()
+  testDb = createTestDb()
+  projectId = seedProject(testDb, seedWorkspace(testDb))
+  suiteId = seedSuite(testDb, projectId)
+  registerTestSuiteHandlers()
+})
+
+describe('testSuite:getRunConfig / saveRunConfig — round-trip', () => {
+  it('a fresh suite has no run config (null)', async () => {
+    const res = await getConfig(suiteId)
+    expect(res.success).toBe(true)
+    expect(res.data).toBeNull()
+  })
+
+  it('save → get returns the exact JSON string', async () => {
+    const saved = await saveConfig(suiteId, SAMPLE_CONFIG)
+    expect(saved.success).toBe(true)
+
+    const res = await getConfig(suiteId)
+    expect(res.success).toBe(true)
+    expect(res.data).toBe(SAMPLE_CONFIG)
+  })
+
+  it('re-saving overwrites the previous config', async () => {
+    await saveConfig(suiteId, SAMPLE_CONFIG)
+    const second = JSON.stringify({ version: 1, items: [], iterations: 7 })
+    await saveConfig(suiteId, second)
+
+    const res = await getConfig(suiteId)
+    expect(res.data).toBe(second)
+  })
+
+  it('saving null clears a stored config', async () => {
+    await saveConfig(suiteId, SAMPLE_CONFIG)
+    const cleared = await saveConfig(suiteId, null)
+    expect(cleared.success).toBe(true)
+
+    const res = await getConfig(suiteId)
+    expect(res.success).toBe(true)
+    expect(res.data).toBeNull()
+  })
+
+  it('save bumps the suite updated_at', async () => {
+    testDb.prepare('UPDATE test_suites SET updated_at = 1 WHERE id = ?').run(suiteId)
+    await saveConfig(suiteId, SAMPLE_CONFIG)
+    const row = testDb
+      .prepare('SELECT updated_at FROM test_suites WHERE id = ?')
+      .get(suiteId) as { updated_at: number }
+    expect(row.updated_at).toBeGreaterThan(1)
+  })
+})
+
+describe('testSuite run config — error paths', () => {
+  it('getRunConfig on an unknown suite fails', async () => {
+    const res = await getConfig(crypto.randomUUID())
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/not found/i)
+  })
+
+  it('saveRunConfig on an unknown suite fails', async () => {
+    const res = await saveConfig(crypto.randomUUID(), SAMPLE_CONFIG)
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/not found/i)
+  })
+
+  it('saveRunConfig rejects a non-string, non-null payload', async () => {
+    const res = (await harness.invoke('testSuite:saveRunConfig', suiteId, {
+      version: 1,
+    })) as SaveRes
+    expect(res.success).toBe(false)
+  })
+})
+
+describe('testSuite run config — lifecycle with the suite row', () => {
+  it('deleting the suite removes the config with the row', async () => {
+    await saveConfig(suiteId, SAMPLE_CONFIG)
+    const del = (await harness.invoke('testSuite:delete', suiteId)) as SaveRes
+    expect(del.success).toBe(true)
+
+    // The row is gone, so the config is unreachable — same "not found" as any
+    // other missing suite. Nothing lingers in the table either.
+    const res = await getConfig(suiteId)
+    expect(res.success).toBe(false)
+    const count = testDb
+      .prepare('SELECT COUNT(*) as c FROM test_suites WHERE id = ?')
+      .get(suiteId) as { c: number }
+    expect(count.c).toBe(0)
+  })
+
+  it('duplicating a suite does NOT copy run_config (item ids are reminted)', async () => {
+    await saveConfig(suiteId, SAMPLE_CONFIG)
+    const dup = (await harness.invoke('testSuite:duplicate', suiteId)) as SuiteRes
+    expect(dup.success).toBe(true)
+
+    const copyConfig = await getConfig(dup.data!.id)
+    expect(copyConfig.success).toBe(true)
+    expect(copyConfig.data).toBeNull()
+    // …and the original keeps its own config untouched.
+    const orig = await getConfig(suiteId)
+    expect(orig.data).toBe(SAMPLE_CONFIG)
+  })
+})

--- a/tests/renderer/new-tab-dirty.test.ts
+++ b/tests/renderer/new-tab-dirty.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Issue #101 — new request tabs (New → HTTP etc.) were missing the unsaved
+ * indicator and close confirmation. `markActiveTabDirty` used to gate on the
+ * active tab carrying an `endpointId` / `savedRequestId`, so a brand-new tab
+ * (no backing row yet) could never turn dirty: edits were silently lost on
+ * close, with no dot and no confirm dialog.
+ *
+ * The gate is now "is this a request-like tab" (`isRequestLikeTab`): any tab
+ * backed by an endpoint / saved request / test-suite item row, or a scratch
+ * tab whose protocol is a regular request protocol. Tool tabs, the Runner tab
+ * and the Mock Server editor still never get flagged — they have no request
+ * to be dirty against.
+ *
+ * Also pins the contract Workbench's close-confirm "Save & Close" relies on:
+ * a scratch tab has no in-place row, so `saveActiveRequestInPlace()` must
+ * report `notApplicable` — Workbench routes that to the EndpointSaveModal
+ * (Save As) instead of silently closing the tab.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTabsStore } from '../../src/renderer/stores/tabs.store'
+import { useRequestStore } from '../../src/renderer/stores/request.store'
+import { useGraphQLStore } from '../../src/renderer/stores/graphql.store'
+import { markActiveTabDirty, isRequestLikeTab } from '../../src/renderer/lib/mark-dirty'
+import { saveActiveRequestInPlace } from '../../src/renderer/lib/save-active-request'
+import type { Tab } from '../../src/renderer/types'
+
+/** Open a single tab and make it active. */
+function openTab(over: Partial<Tab> & { id: string; protocol: Tab['protocol'] }): void {
+  useTabsStore.setState({
+    tabs: [
+      {
+        name: 'Tab',
+        isDirty: false,
+        isLoading: false,
+        ...over,
+      } as Tab,
+    ],
+    activeTabId: over.id,
+  })
+}
+
+function isActiveTabDirty(): boolean {
+  const { tabs, activeTabId } = useTabsStore.getState()
+  return tabs.find((t) => t.id === activeTabId)?.isDirty ?? false
+}
+
+beforeEach(() => {
+  ;(globalThis as unknown as { window: { api: unknown } }).window = { api: {} }
+  useTabsStore.setState({ tabs: [], activeTabId: null })
+})
+
+describe('new-tab dirty indicator (#101)', () => {
+  it('marks a brand-new HTTP tab (no backing ids) dirty when the URL is edited', () => {
+    openTab({ id: 'tab-new-http', name: 'New Request', protocol: 'http', method: 'GET' })
+    expect(isActiveTabDirty()).toBe(false)
+    useRequestStore.getState().switchToTab('tab-new-http')
+    expect(isActiveTabDirty()).toBe(false) // hydration is not an edit
+    useRequestStore.getState().setUrl('https://api.example.test/users')
+    expect(isActiveTabDirty()).toBe(true)
+  })
+
+  it('marks a brand-new protocol tab (New → GraphQL) dirty on edit', () => {
+    openTab({ id: 'tab-new-gql', name: 'GraphQL', protocol: 'graphql' })
+    expect(isActiveTabDirty()).toBe(false)
+    useGraphQLStore.getState().setQuery('query { me { id } }')
+    expect(isActiveTabDirty()).toBe(true)
+  })
+
+  it('marks a test-suite-item tab dirty on edit (in-place savable row)', () => {
+    openTab({ id: 'tab-suite', protocol: 'http', testSuiteItemId: 'tsi-1' })
+    useRequestStore.getState().switchToTab('tab-suite')
+    useRequestStore.getState().setUrl('https://api.example.test/suite')
+    expect(isActiveTabDirty()).toBe(true)
+  })
+
+  it('never marks tool / runner / mock-server tabs dirty', () => {
+    for (const protocol of ['tools.jwt', 'runner', 'mockServer'] as const) {
+      openTab({ id: `tab-${protocol}`, protocol })
+      markActiveTabDirty()
+      expect(isActiveTabDirty(), `protocol ${protocol} must stay clean`).toBe(false)
+    }
+  })
+
+  it('markDirty(false) clears the flag after a first save (EndpointSaveModal path)', () => {
+    openTab({ id: 'tab-new-http-2', protocol: 'http' })
+    useRequestStore.getState().switchToTab('tab-new-http-2')
+    useRequestStore.getState().setUrl('https://api.example.test')
+    expect(isActiveTabDirty()).toBe(true)
+    // EndpointSaveModal's success path does exactly this (markDirty false +
+    // attaches the new savedRequestId).
+    useTabsStore.getState().markDirty('tab-new-http-2', false)
+    useTabsStore.getState().updateTab('tab-new-http-2', { savedRequestId: 'sr-new' })
+    expect(isActiveTabDirty()).toBe(false)
+  })
+
+  it('in-place save on a saved-request tab clears the dirty flag', async () => {
+    const update = vi.fn(async () => ({ success: true }))
+    ;(globalThis as unknown as { window: { api: unknown } }).window = {
+      api: { savedRequest: { update } },
+    }
+    openTab({ id: 'tab-saved', protocol: 'http', savedRequestId: 'sr-1' })
+    useRequestStore.getState().switchToTab('tab-saved')
+    useRequestStore.getState().setUrl('https://api.example.test/edited')
+    expect(isActiveTabDirty()).toBe(true)
+    const result = await saveActiveRequestInPlace()
+    expect(result.success).toBe(true)
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(isActiveTabDirty()).toBe(false)
+  })
+
+  it('saveActiveRequestInPlace reports notApplicable for a scratch tab (Workbench routes this to Save As)', async () => {
+    openTab({ id: 'tab-scratch', protocol: 'http' })
+    useRequestStore.getState().switchToTab('tab-scratch')
+    const result = await saveActiveRequestInPlace()
+    expect(result.success).toBe(false)
+    expect(result.notApplicable).toBe(true)
+  })
+})
+
+describe('isRequestLikeTab (#101)', () => {
+  const base = { id: 't', name: 'T', isDirty: false, isLoading: false }
+
+  it('accepts scratch tabs for every request protocol', () => {
+    const requestProtocols: Tab['protocol'][] = [
+      'http',
+      'soap',
+      'websocket',
+      'graphql',
+      'grpc',
+      'sse',
+      'ai',
+      'mcp',
+      'socketio',
+    ]
+    for (const protocol of requestProtocols) {
+      expect(isRequestLikeTab({ ...base, protocol }), protocol).toBe(true)
+    }
+  })
+
+  it('accepts row-backed tabs regardless of protocol', () => {
+    expect(isRequestLikeTab({ ...base, protocol: 'http', endpointId: 'ep' })).toBe(true)
+    expect(isRequestLikeTab({ ...base, protocol: 'soap', savedRequestId: 'sr' })).toBe(true)
+    expect(isRequestLikeTab({ ...base, protocol: 'http', testSuiteItemId: 'tsi' })).toBe(true)
+  })
+
+  it('rejects tool, runner and mock-server tabs', () => {
+    expect(isRequestLikeTab({ ...base, protocol: 'tools.jwt' })).toBe(false)
+    expect(isRequestLikeTab({ ...base, protocol: 'tools.regex' })).toBe(false)
+    expect(isRequestLikeTab({ ...base, protocol: 'runner' })).toBe(false)
+    expect(isRequestLikeTab({ ...base, protocol: 'mockServer' })).toBe(false)
+  })
+})

--- a/tests/renderer/protocol-dirty-indicator.test.ts
+++ b/tests/renderer/protocol-dirty-indicator.test.ts
@@ -4,8 +4,10 @@
  * shared `markActiveTabDirty` helper so editing a SOAP / WebSocket / SSE /
  * Socket.IO / gRPC / GraphQL request flags its tab dirty too.
  *
- * `markActiveTabDirty` only marks tabs that are backed by a saved request /
- * endpoint, so each case below opens a tab carrying a `savedRequestId` and
+ * `markActiveTabDirty` marks every request-like tab — row-backed (saved
+ * request / endpoint / test-suite item) AND brand-new scratch tabs (issue
+ * #101; scratch tabs used to be exempt, which silently discarded their edits
+ * on close). Each case below opens a tab carrying a `savedRequestId` and
  * makes it active before driving a representative setter.
  *
  * It must ALSO stay clean across the hydration paths: switching to a tab and
@@ -95,7 +97,7 @@ describe('protocol dirty indicator (#8)', () => {
     expect(isActiveTabDirty()).toBe(true)
   })
 
-  it('does not flag a scratch tab (no saved request / endpoint backing)', () => {
+  it('flags a scratch request tab too — new tabs must not lose edits silently (#101)', () => {
     useTabsStore.setState({
       tabs: [
         { id: 'tab-scratch', name: 'Scratch', protocol: 'graphql', isDirty: false, isLoading: false },
@@ -103,7 +105,7 @@ describe('protocol dirty indicator (#8)', () => {
       activeTabId: 'tab-scratch',
     })
     useGraphQLStore.getState().setQuery('query { me { id } }')
-    expect(isActiveTabDirty()).toBe(false)
+    expect(isActiveTabDirty()).toBe(true)
   })
 
   it('switchToTab does NOT flag the target tab dirty (hydration path)', () => {

--- a/tests/renderer/suite-creation-feedback.test.tsx
+++ b/tests/renderer/suite-creation-feedback.test.tsx
@@ -87,13 +87,22 @@ function installApi(create: CreateResult, importRes: ImportResult): void {
   }
 }
 
-/** Right-click the folder and pick "Create Test Suite from this folder". */
-async function createSuiteFromFolder(): Promise<void> {
+/**
+ * Right-click the folder and pick "Create Test Suite from this folder".
+ * Since #102 a request-selection modal sits between the menu item and the
+ * create; confirming its default (everything selected) reproduces the old
+ * one-click behaviour these tests were written against. The empty-folder case
+ * never reaches the modal, so it passes `confirmModal: false`.
+ */
+async function createSuiteFromFolder(confirmModal = true): Promise<void> {
   const node = screen.getAllByTestId('tree-node').find((n) => n.textContent?.includes(FOLDER))
   if (!node) throw new Error('folder node not rendered')
   fireEvent.contextMenu(node)
   const item = await screen.findByText(/Create Test Suite from this folder/i)
   fireEvent.click(item)
+  if (confirmModal) {
+    fireEvent.click(await screen.findByTestId('suite-select-confirm'))
+  }
 }
 
 beforeEach(() => {
@@ -105,7 +114,10 @@ beforeEach(() => {
     openNodeIds: new Set(['mod', 'folder-a']),
     searchQuery: '',
   })
-  installApi({ success: true, data: { id: 'suite-1' } }, { success: true, data: { added: 1, rejected: 0 } })
+  installApi(
+    { success: true, data: { id: 'suite-1' } },
+    { success: true, data: { added: 1, rejected: 0 } },
+  )
 })
 
 afterEach(cleanup)
@@ -124,7 +136,7 @@ describe('creating a test suite from a folder reports what happened (#96)', () =
   it('says an empty folder is empty instead of doing nothing', async () => {
     useWorkspaceStore.setState({ treeData: tree(false) })
     render(<TreeView />)
-    await createSuiteFromFolder()
+    await createSuiteFromFolder(false)
 
     // The reported symptom is a menu item that appears broken. Any message is
     // better than none; it must not be an error, since nothing went wrong.
@@ -134,7 +146,10 @@ describe('creating a test suite from a folder reports what happened (#96)', () =
   })
 
   it('surfaces a failed create, with the reason', async () => {
-    installApi({ success: false, error: 'name already taken' }, { success: true, data: { added: 0, rejected: 0 } })
+    installApi(
+      { success: false, error: 'name already taken' },
+      { success: true, data: { added: 0, rejected: 0 } },
+    )
     render(<TreeView />)
     await createSuiteFromFolder()
 
@@ -145,7 +160,10 @@ describe('creating a test suite from a folder reports what happened (#96)', () =
   })
 
   it('surfaces a failed import', async () => {
-    installApi({ success: true, data: { id: 'suite-1' } }, { success: false, error: 'suite not found' })
+    installApi(
+      { success: true, data: { id: 'suite-1' } },
+      { success: false, error: 'suite not found' },
+    )
     render(<TreeView />)
     await createSuiteFromFolder()
 
@@ -158,7 +176,10 @@ describe('creating a test suite from a folder reports what happened (#96)', () =
     // The quiet one: a suite built from a folder of 1 that copied 0 used to be
     // indistinguishable from a complete success, and only showed up later as a
     // run that came up short.
-    installApi({ success: true, data: { id: 'suite-1' } }, { success: true, data: { added: 0, rejected: 1 } })
+    installApi(
+      { success: true, data: { id: 'suite-1' } },
+      { success: true, data: { added: 0, rejected: 1 } },
+    )
     render(<TreeView />)
     await createSuiteFromFolder()
 

--- a/tests/renderer/suite-from-folder-selection.test.tsx
+++ b/tests/renderer/suite-from-folder-selection.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * issue #102 — "Create Test Suite from this folder" imported the ENTIRE folder.
+ *
+ * The context-menu item used to call testSuite.create + importEndpoints
+ * immediately with every request id under the folder. Users who wanted a
+ * subset had to create the suite and then prune it by hand. A selection step
+ * now sits between the menu item and the create: a checkbox list of the
+ * folder's subtree, everything selected by default (so confirming straight
+ * away reproduces the old one-click behaviour), folder rows toggling their
+ * whole subtree, and Cancel creating nothing at all.
+ *
+ * The handler lives inside TreeView, so these drive it through the context
+ * menu — the way it is actually reached (same approach as the #96 suite).
+ */
+import * as React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+
+const toastCalls: Array<{ kind: string; message: string }> = []
+vi.mock('../../src/renderer/lib/toast', () => ({
+  toast: {
+    success: (m: string) => toastCalls.push({ kind: 'success', message: m }),
+    error: (m: string) => toastCalls.push({ kind: 'error', message: m }),
+    info: (m: string) => toastCalls.push({ kind: 'info', message: m }),
+    warning: (m: string) => toastCalls.push({ kind: 'warning', message: m }),
+  },
+}))
+
+vi.mock('../../src/renderer/components/shared/MonacoWrapper', () => ({
+  default: () => <div data-testid="monaco" />,
+}))
+
+// jsdom gives the scroll container a 0px rect, so the real virtualizer renders
+// no rows. Same pass-through stub the other tree suites use.
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 30,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        key: index,
+        index,
+        start: index * 30,
+        size: 30,
+      })),
+  }),
+}))
+
+import TreeView from '../../src/renderer/components/sidebar/TreeView'
+import { useWorkspaceStore } from '../../src/renderer/stores/workspace.store'
+import type { TreeNode } from '../../src/renderer/types'
+
+const FOLDER = 'Collection A'
+const SUBFOLDER_ID = 'folder-sub'
+const REQUEST = 'Get one'
+
+/** folder-a { req-1, req-2, folder-sub { req-3 } } — three requests total. */
+function tree(): TreeNode[] {
+  return [
+    {
+      id: 'mod',
+      type: 'module',
+      label: 'Default module',
+      children: [
+        {
+          id: 'folder-a',
+          type: 'folder',
+          label: FOLDER,
+          children: [
+            { id: 'req-1', type: 'request', label: REQUEST, method: 'GET', path: '/one' },
+            { id: 'req-2', type: 'request', label: 'Make two', method: 'POST', path: '/two' },
+            {
+              id: SUBFOLDER_ID,
+              type: 'folder',
+              label: 'Subfolder',
+              children: [
+                { id: 'req-3', type: 'request', label: 'Get three', method: 'GET', path: '/three' },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ]
+}
+
+const createCalls: Array<Record<string, unknown>> = []
+const importCalls: Array<{ suite_id: string; endpoint_ids: string[]; source_folder_id?: string }> =
+  []
+
+function installApi(): void {
+  const w = window as unknown as { api: Record<string, unknown> }
+  w.api = {
+    ...(w.api ?? {}),
+    testSuite: {
+      create: (payload: Record<string, unknown>) => {
+        createCalls.push(payload)
+        return Promise.resolve({ success: true, data: { id: 'suite-1' } })
+      },
+      importEndpoints: (payload: {
+        suite_id: string
+        endpoint_ids: string[]
+        source_folder_id?: string
+      }) => {
+        importCalls.push(payload)
+        return Promise.resolve({
+          success: true,
+          data: { added: payload.endpoint_ids.length, rejected: 0 },
+        })
+      },
+    },
+  }
+}
+
+/** Right-click a tree row by its visible label and pick a context-menu entry. */
+async function pickContextAction(rowLabel: string, action: RegExp): Promise<void> {
+  const node = screen.getAllByTestId('tree-node').find((n) => n.textContent?.includes(rowLabel))
+  if (!node) throw new Error(`tree node "${rowLabel}" not rendered`)
+  fireEvent.contextMenu(node)
+  const item = await screen.findByText(action)
+  fireEvent.click(item)
+}
+
+const openSelection = (): Promise<void> =>
+  pickContextAction(FOLDER, /Create Test Suite from this folder/i)
+
+function requestCheckbox(id: string): HTMLInputElement {
+  return screen.getByTestId(`suite-select-request-${id}`) as HTMLInputElement
+}
+
+beforeEach(() => {
+  toastCalls.length = 0
+  createCalls.length = 0
+  importCalls.length = 0
+  useWorkspaceStore.setState({
+    activeWorkspaceId: 'ws-1',
+    activeProjectId: 'proj-1',
+    treeData: tree(),
+    openNodeIds: new Set(['mod', 'folder-a', SUBFOLDER_ID]),
+    searchQuery: '',
+  })
+  installApi()
+})
+
+afterEach(cleanup)
+
+describe('folder → test suite goes through a selection step (#102)', () => {
+  it('opens the selection modal instead of creating immediately, everything checked', async () => {
+    render(<TreeView />)
+    await openSelection()
+
+    await screen.findByTestId('suite-select-modal')
+    // Nothing has been created yet — that is the whole point of the issue.
+    expect(createCalls).toHaveLength(0)
+    expect(importCalls).toHaveLength(0)
+
+    // Default = all selected, so one more click reproduces the old behaviour.
+    for (const id of ['req-1', 'req-2', 'req-3']) {
+      expect(requestCheckbox(id).checked).toBe(true)
+    }
+    expect(screen.getByTestId('suite-select-count').textContent).toContain('3/3')
+  })
+
+  it('confirming the default selection recreates the old full-folder result', async () => {
+    render(<TreeView />)
+    await openSelection()
+
+    fireEvent.click(await screen.findByTestId('suite-select-confirm'))
+
+    await waitFor(() => expect(importCalls).toHaveLength(1))
+    expect(createCalls).toHaveLength(1)
+    expect(createCalls[0].name).toBe(FOLDER)
+    expect(importCalls[0].endpoint_ids).toEqual(['req-1', 'req-2', 'req-3'])
+    // The suite IS this folder — subfolders land at the suite root (issue #94).
+    expect(importCalls[0].source_folder_id).toBe('folder-a')
+  })
+
+  it('confirming a subset passes ONLY the selected ids to the create flow', async () => {
+    render(<TreeView />)
+    await openSelection()
+    await screen.findByTestId('suite-select-modal')
+
+    fireEvent.click(requestCheckbox('req-2'))
+    expect(screen.getByTestId('suite-select-count').textContent).toContain('2/3')
+    fireEvent.click(screen.getByTestId('suite-select-confirm'))
+
+    await waitFor(() => expect(importCalls).toHaveLength(1))
+    expect(importCalls[0].endpoint_ids).toEqual(['req-1', 'req-3'])
+  })
+
+  it('a folder row toggles its whole subtree on and off', async () => {
+    render(<TreeView />)
+    await openSelection()
+    await screen.findByTestId('suite-select-modal')
+
+    const sub = screen.getByTestId(`suite-select-folder-${SUBFOLDER_ID}`) as HTMLInputElement
+    fireEvent.click(sub)
+    expect(requestCheckbox('req-3').checked).toBe(false)
+    expect(screen.getByTestId('suite-select-count').textContent).toContain('2/3')
+
+    fireEvent.click(sub)
+    expect(requestCheckbox('req-3').checked).toBe(true)
+    expect(screen.getByTestId('suite-select-count').textContent).toContain('3/3')
+  })
+
+  it('select all / deselect all flips everything, and 0 selected blocks Create', async () => {
+    render(<TreeView />)
+    await openSelection()
+    await screen.findByTestId('suite-select-modal')
+
+    fireEvent.click(screen.getByTestId('suite-select-toggle-all'))
+    for (const id of ['req-1', 'req-2', 'req-3']) {
+      expect(requestCheckbox(id).checked).toBe(false)
+    }
+    const confirm = screen.getByTestId('suite-select-confirm') as HTMLButtonElement
+    expect(confirm.disabled).toBe(true)
+    fireEvent.click(confirm)
+    expect(createCalls).toHaveLength(0)
+
+    fireEvent.click(screen.getByTestId('suite-select-toggle-all'))
+    expect(requestCheckbox('req-2').checked).toBe(true)
+    expect(confirm.disabled).toBe(false)
+  })
+
+  it('cancelling creates nothing', async () => {
+    render(<TreeView />)
+    await openSelection()
+    await screen.findByTestId('suite-select-modal')
+
+    fireEvent.click(screen.getByTestId('suite-select-cancel'))
+
+    await waitFor(() => expect(screen.queryByTestId('suite-select-modal')).toBeNull())
+    expect(createCalls).toHaveLength(0)
+    expect(importCalls).toHaveLength(0)
+    expect(toastCalls).toHaveLength(0)
+  })
+
+  it('a single request keeps the direct path — nothing to choose from', async () => {
+    render(<TreeView />)
+    await pickContextAction(REQUEST, /Create Test Suite from this request/i)
+
+    await waitFor(() => expect(importCalls).toHaveLength(1))
+    expect(screen.queryByTestId('suite-select-modal')).toBeNull()
+    expect(importCalls[0].endpoint_ids).toEqual(['req-1'])
+  })
+})

--- a/tests/renderer/suite-run-config.test.ts
+++ b/tests/renderer/suite-run-config.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Issue #100 — pure helpers behind the per-suite Runner config persistence:
+ * `parseSuiteRunConfig` (tolerant JSON → SuiteRunConfig), `buildSuiteRunConfig`
+ * (RunnerTab state → serialisable config), and `applyRunConfigToItems`
+ * (config → sequence items, unknown ids ignored, new items keep defaults).
+ *
+ * These are the renderer's load/apply logic; RunnerTab only wires them to the
+ * `testSuite:getRunConfig` / `saveRunConfig` IPC pair.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  parseSuiteRunConfig,
+  buildSuiteRunConfig,
+  applyRunConfigToItems,
+} from '../../src/renderer/lib/suite-run-config'
+import type { SuiteRunConfig } from '../../src/renderer/types'
+
+const OPTIONS = {
+  delay: 250,
+  iterationDelay: 1000,
+  iterations: 3,
+  stopOnError: false,
+  persistResponses: true,
+  keepVariableValues: false,
+  environmentId: 'env-9',
+  runPreScript: 'pm.environment.set("a", "1")',
+  runPostScript: 'console.log("done")',
+}
+
+type SeqItem = { id: string; selected: boolean; phase?: 'setup' | 'main' | 'teardown'; name?: string }
+
+const ITEMS: SeqItem[] = [
+  { id: 'a', selected: true, phase: 'setup', name: 'Login' },
+  { id: 'b', selected: false, name: 'Broken one' },
+  { id: 'c', selected: true, phase: 'teardown', name: 'Cleanup' },
+]
+
+describe('buildSuiteRunConfig → parseSuiteRunConfig round-trip', () => {
+  it('serialises items + options and parses back identically', () => {
+    const config = buildSuiteRunConfig(ITEMS, OPTIONS)
+    const parsed = parseSuiteRunConfig(JSON.stringify(config))
+    expect(parsed).not.toBeNull()
+    expect(parsed).toEqual(config)
+    expect(parsed!.version).toBe(1)
+    expect(parsed!.items).toEqual([
+      { id: 'a', selected: true, phase: 'setup' },
+      { id: 'b', selected: false },
+      { id: 'c', selected: true, phase: 'teardown' },
+    ])
+    expect(parsed!.iterations).toBe(3)
+    expect(parsed!.stopOnError).toBe(false)
+    expect(parsed!.runPreScript).toBe(OPTIONS.runPreScript)
+  })
+
+  it('omits empty optional fields rather than storing empty strings', () => {
+    const config = buildSuiteRunConfig(ITEMS, {
+      ...OPTIONS,
+      environmentId: '',
+      runPreScript: '',
+      runPostScript: '   ',
+    })
+    expect(config.environmentId).toBeUndefined()
+    expect(config.runPreScript).toBeUndefined()
+    expect(config.runPostScript).toBeUndefined()
+  })
+
+  it('does not store a phase for flow ("main") items — omitted means main', () => {
+    const config = buildSuiteRunConfig([{ id: 'x', selected: true, phase: 'main' }], OPTIONS)
+    expect(config.items[0].phase).toBeUndefined()
+  })
+})
+
+describe('parseSuiteRunConfig — tolerant loading', () => {
+  it.each([null, undefined, '', 'not-json', '42', '"str"', '[]'])(
+    'returns null for unusable input %s',
+    (raw) => {
+      expect(parseSuiteRunConfig(raw as string | null | undefined)).toBeNull()
+    },
+  )
+
+  it('returns null when items is missing or not an array', () => {
+    expect(parseSuiteRunConfig(JSON.stringify({ version: 1 }))).toBeNull()
+    expect(parseSuiteRunConfig(JSON.stringify({ version: 1, items: 'x' }))).toBeNull()
+  })
+
+  it('drops malformed item entries but keeps the valid ones', () => {
+    const raw = JSON.stringify({
+      version: 1,
+      items: [
+        { id: 'ok', selected: true },
+        { id: 42, selected: true }, // bad id
+        'garbage',
+        { id: 'ok2', selected: false, phase: 'bogus-phase' }, // bad phase → stripped
+      ],
+      delay: 5,
+    })
+    const parsed = parseSuiteRunConfig(raw)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.items).toEqual([
+      { id: 'ok', selected: true },
+      { id: 'ok2', selected: false },
+    ])
+  })
+
+  it('fills sane defaults for missing numeric/boolean options', () => {
+    const parsed = parseSuiteRunConfig(JSON.stringify({ version: 1, items: [] }))
+    expect(parsed).not.toBeNull()
+    expect(parsed!.delay).toBe(0)
+    expect(parsed!.iterationDelay).toBe(0)
+    expect(parsed!.iterations).toBe(1)
+    expect(parsed!.stopOnError).toBe(true)
+    expect(parsed!.persistResponses).toBe(true)
+    expect(parsed!.keepVariableValues).toBe(true)
+  })
+
+  it('sanitises out-of-range numbers instead of trusting the blob', () => {
+    const parsed = parseSuiteRunConfig(
+      JSON.stringify({ version: 1, items: [], iterations: -3, delay: 'NaN', iterationDelay: -1 }),
+    )
+    expect(parsed!.iterations).toBe(1)
+    expect(parsed!.delay).toBe(0)
+    expect(parsed!.iterationDelay).toBe(0)
+  })
+})
+
+describe('applyRunConfigToItems', () => {
+  const config: SuiteRunConfig = {
+    version: 1,
+    items: [
+      { id: 'a', selected: false },
+      { id: 'c', selected: true, phase: 'setup' },
+      { id: 'ghost', selected: false, phase: 'teardown' }, // deleted since the save
+    ],
+    delay: 0,
+    iterationDelay: 0,
+    iterations: 1,
+    stopOnError: true,
+    persistResponses: true,
+    keepVariableValues: true,
+  }
+
+  it('applies selected + phase by id and leaves unknown-to-config items on defaults', () => {
+    const fresh: SeqItem[] = [
+      { id: 'a', selected: true, name: 'Login' },
+      { id: 'b', selected: true, name: 'New since save' },
+      { id: 'c', selected: true, name: 'Cleanup' },
+    ]
+    const applied = applyRunConfigToItems(fresh, config)
+    expect(applied).toEqual([
+      { id: 'a', selected: false, phase: undefined, name: 'Login' },
+      { id: 'b', selected: true, name: 'New since save' },
+      { id: 'c', selected: true, phase: 'setup', name: 'Cleanup' },
+    ])
+  })
+
+  it('ignores config entries whose item no longer exists', () => {
+    const applied = applyRunConfigToItems([{ id: 'a', selected: true }], config)
+    expect(applied.map((i) => i.id)).toEqual(['a'])
+  })
+
+  it('does not mutate the input array', () => {
+    const fresh: SeqItem[] = [{ id: 'a', selected: true }]
+    applyRunConfigToItems(fresh, config)
+    expect(fresh[0].selected).toBe(true)
+  })
+})

--- a/website/src/content/docs/certificates.md
+++ b/website/src/content/docs/certificates.md
@@ -84,6 +84,23 @@ handshake. The hostname field supports:
 If multiple certificates match a hostname, the most specific pattern wins
 (exact > subdomain wildcard > `*`).
 
+### Runs present client certificates too
+
+The **Collection Runner**, **test suites** and **scheduled runs** use the exact
+same certificate logic as Send — a request that authenticates via mTLS when
+you press Send authenticates the same way in a run.
+
+Certificates are still matched to the request host, but a client certificate
+whose host is `*` matches **every** host a collection touches — including
+third-party APIs. Give every client certificate a specific host; a wildcard is
+fine for CA / trust entries, but for a client certificate it means your
+identity is presented to every host in the run.
+
+Failures are loud: a matching certificate that cannot be loaded fails that
+single request with a clear message instead of quietly going out
+unauthenticated. `pm.sendRequest(...)` attaches no project certificate, on
+either path.
+
 ## CA certificates (custom trust anchors)
 
 Use this when your server presents a certificate signed by a private CA —

--- a/website/src/content/docs/cli-and-automation.md
+++ b/website/src/content/docs/cli-and-automation.md
@@ -56,6 +56,13 @@ preference, it is what a failed precondition means.
 line, not in the top-level error count. A cleanup step that fails is worth
 seeing, but it does not turn a passing run into a failing one.
 
+**Run-level scripts.** Alongside the per-request roles, the run configuration
+has a **Run setup script** and a **Run teardown script**. They execute once per
+run — not once per iteration — and the teardown script is guaranteed the same
+way teardown requests are: it still runs when the flow stops early. In the
+results, script rows carry a **SCRIPT** chip rather than a status code, and a
+script that threw is reported as an error.
+
 ### Stopping a run
 
 Two buttons, and they mean different things in every phase:

--- a/website/src/content/docs/features.md
+++ b/website/src/content/docs/features.md
@@ -106,11 +106,26 @@ Base converter · Regex tester · Diff · Epoch / timestamp · UUID generator ·
 JSON ↔ XML · YAML ↔ JSON · Jolt transform · JSON Schema · JSON / XML formatter ·
 HTTP status reference · WS-Security helper.
 
+## Security tools
+
+The **Security** page collects the key, PKI, token and identity suite:
+[Keystore Studio](/docs/keystore-studio) (JKS / PKCS#12),
+[JWK / JWKS](/docs/jwk-jwks), the [JWT / JOSE debugger](/docs/jwt-debugger)
+(sign, verify, JWE), the [TLS Inspector](/docs/tls-inspector),
+[SAML](/docs/saml) build / sign / validate, plus an OTP Authenticator
+(TOTP / HOTP), a Password Generator and a QR tool. All of it runs offline —
+except the TLS Inspector, which by design connects to the endpoint you point
+it at.
+
 ## Organization & version control
 
 - **Workspaces → Projects → Branches** hierarchy
 - **Git integration** (per-project branches, conflict handling) — see [Git integration](/docs/git-branches)
 - Endpoint / folder tree with drag-and-drop ordering
+- Tree **search** that keeps a matching folder's whole subtree — root-level
+  requests included (Postman / Insomnia behaviour)
+- Right-click a folder → **Expand All / Collapse All** for the whole subtree,
+  even while a search filter is active
 
 ## Request history
 

--- a/website/src/content/docs/protocols/http.md
+++ b/website/src/content/docs/protocols/http.md
@@ -11,8 +11,13 @@ your browser sandbox.
 
 ## Methods
 
-GET · POST · PUT · PATCH · DELETE · HEAD · OPTIONS · CONNECT · TRACE, plus any
-custom method string you type in the method picker.
+GET · POST · PUT · PATCH · DELETE · HEAD · OPTIONS · QUERY · CONNECT · TRACE,
+plus any custom method string you type in the method picker.
+
+**QUERY** is the safe, idempotent method that carries a request body — the
+standard answer to "GET with a body, or POST?" for reads whose parameters do
+not fit in a URL. It has its own badge and is also selectable in
+[mock servers](/docs/mock-server).
 
 ## URL bar
 
@@ -143,6 +148,29 @@ are persisted to history.
 
 The status line above the tabs shows HTTP status code (colored by class),
 response time (ms), and response size.
+
+## Cookies
+
+Testnizer keeps an automatic, **project-scoped cookie jar**. When a response
+carries `Set-Cookie`, the cookie is stored and sent automatically — as a
+`Cookie` header — on subsequent requests in the same project that match the
+cookie's domain and path. A login request followed by an authenticated request
+works with zero configuration, the way it does in a browser.
+
+One jar per project, on every path:
+
+- **Send**, the **Collection Runner**, **test suites**, **scheduled runs** and
+  script-driven `pm.sendRequest(...)` calls all share the same jar — a login
+  done via Send is visible to a Run, and a `pm.sendRequest` login benefits the
+  requests that follow it.
+- Different projects are **isolated** from each other: a session cookie stored
+  in one project is never sent from another, even for the same host.
+- **Quick Test** uses a separate, unscoped jar by design.
+
+The jar lives in memory — restarting Testnizer clears it. Cookies set by the
+current response are listed in the **Cookies** tab of the response pane with
+their domain, path and flags; long values (JWT-sized tokens) wrap inside their
+own column and stay selectable for copying.
 
 ## Code snippet generation
 

--- a/website/src/content/docs/scripts.md
+++ b/website/src/content/docs/scripts.md
@@ -121,13 +121,19 @@ pm.info.requestId        // the request's id
 
 ### pm.cookies
 
-The cookie jar shared with the request:
+The cookies visible on the current exchange (the same set as
+`pm.response.cookies`):
 
 ```js
 pm.cookies.get('session')   // → value | undefined
 pm.cookies.has('session')   // → boolean
 pm.cookies.toObject()       // → { name: value, ... }
 ```
+
+Cookie *storage* is handled outside the script: Testnizer keeps an automatic
+project-scoped cookie jar, so a `Set-Cookie` from one request is sent on the
+requests that follow it — see
+[Cookies](/docs/protocols/http#cookies).
 
 ### pm.request (pre-request only)
 
@@ -308,6 +314,15 @@ pm.sendRequest('https://api.example.com/ping', function (err, res) {
 The response exposes the same surface as `pm.response` — `.code`, `.status`,
 `.json()`, `.text()`, `.headers.get(name)`, `.cookies.get(name)`, and so on.
 
+Two scoping rules, identical on Send and Run:
+
+- `pm.sendRequest` shares the **project's cookie jar** with the main request —
+  a login performed in a pre-request script stores its session cookie in the
+  same jar, so the requests that follow send it automatically. See
+  [Cookies](/docs/protocols/http#cookies).
+- It attaches **no project client certificate** (mTLS) — see
+  [Certificates](/docs/certificates).
+
 ### pm.execution
 
 ```js
@@ -418,6 +433,16 @@ Configure them in:
 This is ideal for cross-cutting setup — e.g. a project pre-request script that
 refreshes a token once, inherited by every request below it. The cascade applies
 to both **Send** and **Run**.
+
+### Run-level setup & teardown scripts
+
+The Collection Runner's configuration carries two more slots: **Run setup
+script** and **Run teardown script**. They execute **once per run** — not once
+per iteration — before the first request and after the last. The teardown
+script is guaranteed: it still runs when the run stops early on an error or a
+manual Stop. In the results, script rows appear with a **SCRIPT** chip, and a
+script that threw is reported as an error. See
+[Setup, Flow and Teardown](/docs/cli-and-automation#setup-flow-and-teardown).
 
 ## Auth inheritance
 

--- a/website/src/content/docs/tr/certificates.md
+++ b/website/src/content/docs/tr/certificates.md
@@ -84,6 +84,22 @@ seçer. Ana bilgisayar adı alanı şunları destekler:
 Birden fazla sertifika bir ana bilgisayar adıyla eşleşirse, en spesifik kalıp
 kazanır (tam > alt etki alanı joker > `*`).
 
+### Koşular da istemci sertifikası sunar
+
+**Collection Runner**, **test suite'leri** ve **zamanlanmış koşular**, Send ile
+birebir aynı sertifika mantığını kullanır — Send'e bastığınızda mTLS ile kimlik
+doğrulayan bir istek, bir koşuda da aynı şekilde doğrular.
+
+Sertifikalar yine isteğin host'una göre eşleştirilir; ancak host'u `*` olan bir
+istemci sertifikası, koleksiyonun dokunduğu **her** host'la eşleşir — üçüncü
+taraf API'ler dahil. Her istemci sertifikasına spesifik bir host verin; joker
+karakter CA / güven girdileri için sorun değildir, ama bir istemci sertifikası
+için kimliğinizin koşudaki her host'a sunulması anlamına gelir.
+
+Hatalar sessiz kalmaz: eşleşen ama yüklenemeyen bir sertifika, isteği sessizce
+kimliksiz göndermek yerine o tek isteği net bir mesajla başarısız kılar.
+`pm.sendRequest(...)` iki yolda da proje sertifikası eklemez.
+
 ## CA sertifikaları (özel güven çıpaları)
 
 Sunucunuz özel bir CA tarafından imzalanmış bir sertifika sunduğunda bunu kullanın

--- a/website/src/content/docs/tr/cli-and-automation.md
+++ b/website/src/content/docs/tr/cli-and-automation.md
@@ -57,6 +57,13 @@ başarısız bir ön koşulun anlamıdır.
 satırında sayılır, üst düzey hata sayacında değil. Başarısız bir temizlik adımı
 görülmeye değerdir, ama geçen bir koşuyu kalan bir koşuya çevirmez.
 
+**Run düzeyi betikler.** İstek başına rollerin yanında, koşu yapılandırmasında
+bir **Run setup script** ve bir **Run teardown script** vardır. Bunlar
+iterasyon başına değil, run başına bir kez çalışır — ve teardown betiği,
+teardown isteklerinin garantilendiği şekilde garantilidir: akış erken
+durduğunda da koşar. Sonuçlarda betik satırları bir durum kodu yerine
+**SCRIPT** rozeti taşır ve hata fırlatan bir betik hata olarak raporlanır.
+
 ### Bir koşuyu durdurmak
 
 İki buton ve her aşamada farklı anlamları var:

--- a/website/src/content/docs/tr/features.md
+++ b/website/src/content/docs/tr/features.md
@@ -106,11 +106,26 @@ Base dönüştürücü · Regex test · Diff · Epoch / timestamp · UUID üreti
 JSON ↔ XML · YAML ↔ JSON · Jolt transform · JSON Schema · JSON / XML formatlayıcı ·
 HTTP status referansı · WS-Security yardımcısı.
 
+## Güvenlik araçları
+
+**Security** sayfası anahtar, PKI, token ve kimlik takımını bir arada toplar:
+[Keystore Studio](/tr/docs/keystore-studio) (JKS / PKCS#12),
+[JWK / JWKS](/tr/docs/jwk-jwks), [JWT / JOSE debugger](/tr/docs/jwt-debugger)
+(imzalama, doğrulama, JWE), [TLS Inspector](/tr/docs/tls-inspector),
+[SAML](/tr/docs/saml) oluşturma / imzalama / doğrulama; ayrıca bir OTP
+Authenticator (TOTP / HOTP), bir Parola Üretici ve bir QR aracı. Tamamı offline
+çalışır — tasarımı gereği işaret ettiğiniz endpoint'e bağlanan TLS Inspector
+hariç.
+
 ## Organizasyon & versiyon kontrol
 
 - **Workspace → Proje → Branch** hiyerarşisi
 - **Git entegrasyonu** (proje başına branch, conflict yönetimi) — bkz. [Git entegrasyonu](/tr/docs/git-branches)
 - Sürükle-bırak sıralamalı endpoint / klasör ağacı
+- Eşleşen bir klasörün **tüm alt ağacını** koruyan ağaç **araması** — kök
+  düzeydeki istekler dahil (Postman / Insomnia davranışı)
+- Bir klasöre sağ tıklayın → tüm alt ağaç için **Expand All / Collapse All** —
+  arama filtresi aktifken bile
 
 ## İstek geçmişi
 

--- a/website/src/content/docs/tr/protocols/http.md
+++ b/website/src/content/docs/tr/protocols/http.md
@@ -10,8 +10,13 @@ ve tarayıcı sandbox'ınızda değil, Node ana sürecinde çalışan bir script
 
 ## Metodlar
 
-GET · POST · PUT · PATCH · DELETE · HEAD · OPTIONS · CONNECT · TRACE ve metod
-seçicide yazdığınız herhangi bir özel metod dizesi.
+GET · POST · PUT · PATCH · DELETE · HEAD · OPTIONS · QUERY · CONNECT · TRACE
+ve metod seçicide yazdığınız herhangi bir özel metod dizesi.
+
+**QUERY**, istek gövdesi taşıyan güvenli ve idempotent metoddur — parametreleri
+bir URL'ye sığmayan okumalar için "GET'e gövde mi, yoksa POST mu?" sorusunun
+standart yanıtı. Kendi rozetine sahiptir ve
+[mock sunucularda](/tr/docs/mock-server) da seçilebilir.
 
 ## URL çubuğu
 
@@ -140,6 +145,29 @@ geçmişe kaydedilir.
 
 Sekmelerin üzerindeki durum satırı HTTP durum kodunu (sınıfa göre renklendirilmiş),
 yanıt süresini (ms) ve yanıt boyutunu gösterir.
+
+## Cookie'ler
+
+Testnizer otomatik, **proje kapsamlı bir cookie kavanozu (cookie jar)** tutar.
+Bir yanıt `Set-Cookie` taşıdığında cookie saklanır ve aynı projede cookie'nin
+domain'i ile path'ine uyan sonraki isteklerde otomatik olarak — `Cookie`
+header'ı şeklinde — gönderilir. Bir login isteğinin ardından gelen kimlik
+doğrulamalı istek, tarayıcıda olduğu gibi sıfır yapılandırmayla çalışır.
+
+Proje başına tek kavanoz, her yolda:
+
+- **Send**, **Collection Runner**, **test suite'leri**, **zamanlanmış
+  çalıştırmalar** ve script kaynaklı `pm.sendRequest(...)` çağrıları aynı
+  kavanozu paylaşır — Send ile yapılan bir login Run'da görünür ve
+  `pm.sendRequest` ile yapılan bir login sonraki isteklere yarar.
+- Farklı projeler birbirinden **izoledir**: bir projede saklanan oturum
+  cookie'si, aynı host için bile başka bir projeden asla gönderilmez.
+- **Quick Test** tasarım gereği ayrı, kapsamsız bir kavanoz kullanır.
+
+Kavanoz bellekte yaşar — Testnizer'ı yeniden başlatmak onu temizler. Geçerli
+yanıtın ayarladığı cookie'ler, yanıt panelinin **Cookies** sekmesinde
+domain'i, path'i ve bayraklarıyla listelenir; uzun değerler (JWT boyutundaki
+token'lar) kendi sütunlarında sarılır ve kopyalamak için seçilebilir kalır.
 
 ## Kod snippet oluşturma
 

--- a/website/src/content/docs/tr/scripts.md
+++ b/website/src/content/docs/tr/scripts.md
@@ -122,13 +122,17 @@ pm.info.requestId        // isteğin id'si
 
 ### pm.cookies
 
-İstekle paylaşılan çerez kavanozu:
+Geçerli alışverişte görünen cookie'ler (`pm.response.cookies` ile aynı küme):
 
 ```js
 pm.cookies.get('session')   // → değer | undefined
 pm.cookies.has('session')   // → boolean
 pm.cookies.toObject()       // → { name: value, ... }
 ```
+
+Cookie *saklama* işi betiğin dışında yürür: Testnizer otomatik, proje kapsamlı
+bir cookie kavanozu tutar; bir istekten gelen `Set-Cookie` sonraki isteklerde
+gönderilir — bkz. [Cookie'ler](/tr/docs/protocols/http#cookieler).
 
 ### pm.request (yalnızca ön istek betiği)
 
@@ -309,6 +313,15 @@ pm.sendRequest('https://api.example.com/ping', function (err, res) {
 Yanıt, `pm.response` ile aynı yüzeyi sunar — `.code`, `.status`, `.json()`,
 `.text()`, `.headers.get(name)`, `.cookies.get(name)` vb.
 
+Send ve Run'da birebir aynı olan iki kapsam kuralı:
+
+- `pm.sendRequest`, ana istekle **projenin cookie kavanozunu** paylaşır — bir ön
+  istek betiğinde yapılan login, oturum cookie'sini aynı kavanoza yazar ve
+  ardından gelen istekler onu otomatik gönderir. Bkz.
+  [Cookie'ler](/tr/docs/protocols/http#cookieler).
+- **Proje istemci sertifikası** (mTLS) eklemez — bkz.
+  [Sertifikalar](/tr/docs/certificates).
+
 ### pm.execution
 
 ```js
@@ -421,6 +434,16 @@ Bunları şuralarda yapılandırın:
 Bu, kesişen kurulumlar için idealdir — örn. bir kez token yenileyen ve altındaki her
 istek tarafından miras alınan bir proje ön istek betiği. Kademelenme hem **Send**
 hem de **Run** için geçerlidir.
+
+### Run düzeyi setup & teardown betikleri
+
+Collection Runner'ın yapılandırmasında iki slot daha vardır: **Run setup
+script** ve **Run teardown script**. Bunlar iterasyon başına değil, **run
+başına bir kez** çalışır — ilk istekten önce ve son istekten sonra. Teardown
+betiği garantilidir: run bir hata ya da elle basılan Stop ile erken durduğunda
+da çalışır. Sonuçlarda betik satırları **SCRIPT** rozetiyle görünür ve hata
+fırlatan bir betik hata olarak raporlanır. Bkz.
+[Setup, Flow ve Teardown](/tr/docs/cli-and-automation#setup-flow-ve-teardown).
 
 ## Auth (kimlik) mirası
 


### PR DESCRIPTION
Fixes the three post-release UX gaps from Aug 10, plus the website-docs gaps for the v1.5.x behaviours.

## issue #100 — Runner: persist run configuration per suite
`test_suites` gains a `run_config` column (CREATE TABLE + idempotent ALTER + the `createTestDb()` test mirror); sequence selection and roles, iterations, delays, stop-on-error, lifecycle scripts and environment save via an explicit **Save configuration** button and restore automatically when the suite reopens. Explicit save, not auto-save: the sidebar Run Suite path rewrites the selection programmatically and would silently clobber a hand-built config. Deliberate boundaries: item order stays in `test_suite_items.sort_order`, file iteration data is not persisted, duplicate doesn't copy the config (regenerated item ids — pinned by test). Side fix: refetches merge previous selection state, so drag-reordering no longer resets roles.

## issue #101 — new request tabs: dirty indicator + close confirmation
`markActiveTabDirty` skipped tabs with no backing row, so New → HTTP tabs never dirtied and closed silently. A shared `isRequestLikeTab` predicate now covers scratch request tabs (tools/runner/mock stay exempt) and Ctrl+S derives from the same export. Two disconnects found on the way: **Save & Close on a new tab was a silent discard** (`notApplicable` fell through to close) — it now opens the Save-As modal; and activating a background tab before Save & Close didn't switch the active tab id, so the closing tab's content **saved into the wrong tab's row** — fixed.

## issue #102 — Create Test Suite from folder: request selection step
The context-menu action now opens a selection modal (tri-state folder rows toggling their subtree, select/deselect all with a counter, everything selected by default, Create disabled at zero). Single request → direct create unchanged; empty-folder toast unchanged; the #96 feedback toasts survive with the selected count as denominator.

## docs (website)
Cookies section (per-project jar semantics) + QUERY on the HTTP page; pm.sendRequest scoping rules, run-level setup/teardown and a corrected pm.cookies on the scripts page; security-tools catalogue, v1.5.1 sidebar items and the TLS-Inspector exception on features; runs-present-client-certificates on certificates. EN + TR, 80-page build verified.

## Verification
- Full unit suite 3556 passed (+44 new, all fail-first), typecheck clean, lint 0 errors
- The one e2e spec driving the suite-creation menu item was updated for the modal and runs in the per-PR shard set
- Outstanding manual checks (pre-release): modal visuals light/dark, RunnerTab save→reopen live flow, background-tab Save & Close, new-tab dirty dot in the live app

🤖 Generated with [Claude Code](https://claude.com/claude-code)