### PR TITLE
fix(ui): close the three gaps the retests found (#97, #100, #112)

### DIFF
--- a/src/renderer/components/layout/Workbench.tsx
+++ b/src/renderer/components/layout/Workbench.tsx
@@ -1051,12 +1051,18 @@ export default function Workbench() {
     }
 
     // No active tab for the current page — show the page's welcome surface.
+    // The strip goes ABOVE it, exactly as in every branch below: issue #97 was
+    // only half-fixed by making `EndpointTabBar` stop returning null at zero
+    // tabs, because this branch — the one that actually renders when the last
+    // tab closes — never mounted the strip at all. PageWelcome fills the space
+    // underneath, so both affordances are present instead of either/or.
     if (!activeTab) {
       return (
         <div
           className="flex flex-1 flex-col overflow-hidden"
           style={{ background: 'var(--white)' }}
         >
+          <EndpointTabBar />
           <PageWelcome page={activeSidebarPage} />
         </div>
       )

--- a/src/renderer/components/runner/RunnerTab.tsx
+++ b/src/renderer/components/runner/RunnerTab.tsx
@@ -834,7 +834,6 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
       // config falls through to defaults — it must never block suite open.
       let config: SuiteRunConfig | null = null
       if (configLoadedForSuiteRef.current !== suiteIdForRunner) {
-        configLoadedForSuiteRef.current = suiteIdForRunner
         try {
           const cfgRes = await window.api?.testSuite?.getRunConfig?.(suiteIdForRunner)
           if (cfgRes?.success) config = parseSuiteRunConfig(cfgRes.data)
@@ -843,6 +842,16 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
           console.warn('runner: failed to load suite run config:', (err as Error).message)
         }
         if (cancelled) return
+        /*
+         * Marked only once the load has actually SURVIVED to here. Marking it
+         * before the await meant a cancelled effect — this one re-runs
+         * whenever its deps change — left the suite flagged as "config
+         * loaded" while nothing had been applied, and the next run skipped
+         * the load for good. That is why the saved config came back only
+         * after a detour through another tab: the remount reset the ref
+         * (issue #100 retest).
+         */
+        configLoadedForSuiteRef.current = suiteIdForRunner
         if (config) {
           setDelay(config.delay)
           setIterationDelay(config.iterationDelay)
@@ -948,7 +957,11 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
       cancelled = true
       window.removeEventListener('tests:suite-item-changed', refetch)
     }
-  }, [suiteIdForRunner, runFolderName])
+    // `runFolderName` is deliberately NOT a dependency: nothing in this effect
+    // reads it, but it is set from the session payload right after mount, and
+    // as a dep that turned every suite open into cancel-and-refetch — the
+    // churn the config load was losing its race against.
+  }, [suiteIdForRunner])
 
   const toggleEndpoint = useCallback((id: string) => {
     setEndpoints((eps) => eps.map((ep) => (ep.id === id ? { ...ep, selected: !ep.selected } : ep)))

--- a/src/renderer/components/sidebar/TreeView.tsx
+++ b/src/renderer/components/sidebar/TreeView.tsx
@@ -23,7 +23,7 @@ import { collectRequestIds } from '../../lib/folder-request-selection'
 import { toast } from '../../lib/toast'
 import { t } from '../../lib/i18n'
 import { openFolderRunner } from '../../lib/open-runner-tab'
-import { openEndpointTab } from '../../lib/open-endpoint-tab'
+import { openEndpointTab, focusOpenTabFor } from '../../lib/open-endpoint-tab'
 import { restoreProtocolFromMetadata } from '../../lib/save-active-request'
 
 // Re-alias for flattenTree signature
@@ -312,6 +312,18 @@ export default function TreeView() {
 
       const tabId = `tab-${node.id}`
       const method = (node.method || 'GET') as HttpMethod
+
+      /*
+       * The request may already be open. Every branch below opens a preview
+       * tab and then re-hydrates it from the DB and calls `clearResponse()` —
+       * but `openPreviewTab` recognises an already-open endpoint / saved
+       * request and just ACTIVATES it, so those two calls landed on a live
+       * tab: the response the user had just received was wiped and the tab
+       * reset to its saved state (issue #112, second path — the tab strip was
+       * fixed, the tree was not). Focus it and stop; the open tab already
+       * holds that state, unsaved edits included.
+       */
+      if (focusOpenTabFor(node.id)) return
 
       if (node.type === 'request') {
         // Load full saved request data from DB

--- a/src/renderer/lib/open-endpoint-tab.ts
+++ b/src/renderer/lib/open-endpoint-tab.ts
@@ -10,6 +10,38 @@ import { useTabsStore } from '../stores/tabs.store'
 import { useRequestStore } from '../stores/request.store'
 import { useResponseStore } from '../stores/response.store'
 import { restoreProtocolFromMetadata } from './save-active-request'
+import { switchActiveTab } from './activate-tab'
+
+/**
+ * If `id` already has a tab open, focus it and report that nothing else is
+ * needed.
+ *
+ * Every open path below finishes with `clearResponse` + a re-hydrate from the
+ * DB, which is right for a tab being filled for the first time and wrong for
+ * one the user is already using: `openPreviewTab` activates an existing tab
+ * rather than minting a second, so those two calls landed on live state and
+ * wiped the response that tab had just received — clicking a request you had
+ * already sent made it look as though you never had (issue #112, the paths
+ * left over after the tab strip was fixed). An open tab is the newer state,
+ * unsaved edits included; the DB copy is not.
+ *
+ * Exported so the APIs tree can ask the same question before its own inline
+ * open path, which predates this helper.
+ */
+export function focusOpenTabFor(id: string): boolean {
+  const existing = useTabsStore
+    .getState()
+    .tabs.find(
+      (tab) =>
+        tab.id === `tab-${id}` ||
+        tab.endpointId === id ||
+        tab.savedRequestId === id ||
+        tab.testSuiteItemId === id,
+    )
+  if (!existing) return false
+  switchActiveTab(existing.id)
+  return true
+}
 
 /**
  * Open an endpoint or saved request in a new (or reused) preview tab and
@@ -23,6 +55,7 @@ import { restoreProtocolFromMetadata } from './save-active-request'
  */
 export async function openEndpointTab(id: string): Promise<void> {
   const tabId = `tab-${id}`
+  if (focusOpenTabFor(id)) return
 
   // Try saved_requests first — the only place users land here from manually
   // created requests is the suite tree, and we want the cheaper lookup to
@@ -201,6 +234,7 @@ export async function openEndpointTab(id: string): Promise<void> {
  */
 export async function openSuiteItemTab(id: string, opts?: { pinned?: boolean }): Promise<void> {
   const tabId = `tab-${id}`
+  if (focusOpenTabFor(id)) return
   try {
     const result = (await window.api?.testSuiteItem?.get(id)) as {
       success: boolean

--- a/tests/renderer/focus-open-tab.test.ts
+++ b/tests/renderer/focus-open-tab.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Issue #112, retest — the response survived tab-to-tab switching but was
+ * still dropped when the same request was clicked again in the sidebar.
+ *
+ * The first fix removed the stray `clearResponse()` from the tab strip's
+ * switch/close handlers. The tree is a second navigation path into the same
+ * tab, and it did something the strip never did: it re-opened the request.
+ * `openPreviewTab` recognises an already-open endpoint and ACTIVATES it
+ * rather than minting a second tab — so the `clearResponse()` and
+ * DB re-hydrate that follow every open landed on a live tab and wiped the
+ * response the user had just received.
+ *
+ * `focusOpenTabFor` is the one gate all of those paths now ask first, which
+ * is why it is tested here rather than in each caller: the defect was that
+ * the paths disagreed.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useTabsStore } from '../../src/renderer/stores/tabs.store'
+import { useResponseStore } from '../../src/renderer/stores/response.store'
+import type { Tab, ApiResponse } from '../../src/renderer/types'
+
+const switchActiveTab = vi.hoisted(() => vi.fn())
+vi.mock('../../src/renderer/lib/activate-tab', () => ({
+  activateTabStores: vi.fn(),
+  switchActiveTab,
+}))
+
+const { focusOpenTabFor, openEndpointTab } = await import(
+  '../../src/renderer/lib/open-endpoint-tab'
+)
+
+function tab(over: Partial<Tab> & { id: string }): Tab {
+  return {
+    name: 'T',
+    protocol: 'http',
+    method: 'GET',
+    url: '',
+    isDirty: false,
+    isLoading: false,
+    ...over,
+  } as Tab
+}
+
+function response(status: number): ApiResponse {
+  return {
+    status,
+    statusText: 'OK',
+    headers: {},
+    body: '{"ok":true}',
+    time: 12,
+    size: 11,
+  } as unknown as ApiResponse
+}
+
+beforeEach(() => {
+  switchActiveTab.mockClear()
+  useTabsStore.setState({ tabs: [], activeTabId: null })
+  useResponseStore.setState({ byTab: {}, response: null, isLoading: false })
+})
+
+describe('focusOpenTabFor (#112)', () => {
+  it('focuses the tab an endpoint already has instead of reopening it', () => {
+    useTabsStore.setState({
+      tabs: [tab({ id: 'tab-ep-1', endpointId: 'ep-1' })],
+      activeTabId: 'tab-ep-1',
+    })
+    expect(focusOpenTabFor('ep-1')).toBe(true)
+    expect(switchActiveTab).toHaveBeenCalledWith('tab-ep-1')
+  })
+
+  it('matches a saved request and a suite item by their own id columns', () => {
+    useTabsStore.setState({
+      tabs: [
+        tab({ id: 'tab-sr-1', savedRequestId: 'sr-1' }),
+        tab({ id: 'tab-tsi-1', testSuiteItemId: 'tsi-1' }),
+      ],
+      activeTabId: 'tab-sr-1',
+    })
+    expect(focusOpenTabFor('sr-1')).toBe(true)
+    expect(focusOpenTabFor('tsi-1')).toBe(true)
+    expect(switchActiveTab).toHaveBeenLastCalledWith('tab-tsi-1')
+  })
+
+  it('matches on the tab id alone, which is how the fallback open path names tabs', () => {
+    // TreeView's "open with basic info" branch mints `tab-${node.id}` with no
+    // endpointId on it at all.
+    useTabsStore.setState({ tabs: [tab({ id: 'tab-ep-9' })], activeTabId: 'tab-ep-9' })
+    expect(focusOpenTabFor('ep-9')).toBe(true)
+  })
+
+  it('reports false for a request that is not open, so the caller opens it', () => {
+    useTabsStore.setState({
+      tabs: [tab({ id: 'tab-ep-1', endpointId: 'ep-1' })],
+      activeTabId: 'tab-ep-1',
+    })
+    expect(focusOpenTabFor('ep-2')).toBe(false)
+    expect(switchActiveTab).not.toHaveBeenCalled()
+  })
+
+  it('leaves no trace when nothing is open at all', () => {
+    expect(focusOpenTabFor('ep-1')).toBe(false)
+    expect(switchActiveTab).not.toHaveBeenCalled()
+  })
+})
+
+describe('the reported symptom (#112)', () => {
+  it('keeps the response when the open request is clicked again in the tree', async () => {
+    useTabsStore.setState({
+      tabs: [tab({ id: 'tab-ep-1', endpointId: 'ep-1' })],
+      activeTabId: 'tab-ep-1',
+    })
+    useResponseStore.getState().setResponse(response(200), 'tab-ep-1')
+    expect(useResponseStore.getState().response?.status).toBe(200)
+
+    // Clicking the row again used to run the full open path over the live tab.
+    await openEndpointTab('ep-1')
+
+    expect(useResponseStore.getState().byTab['tab-ep-1']?.response?.status).toBe(200)
+    expect(switchActiveTab).toHaveBeenCalledWith('tab-ep-1')
+  })
+
+  it('does not go to the database for a tab it already has', async () => {
+    const get = vi.fn(async () => ({ success: true, data: null }))
+    ;(window as unknown as { api: unknown }).api = {
+      savedRequest: { get },
+      endpoint: { get },
+    }
+    useTabsStore.setState({
+      tabs: [tab({ id: 'tab-ep-1', endpointId: 'ep-1' })],
+      activeTabId: 'tab-ep-1',
+    })
+
+    await openEndpointTab('ep-1')
+
+    // The DB copy is the older state — an open tab may hold unsaved edits.
+    expect(get).not.toHaveBeenCalled()
+  })
+})

--- a/tests/renderer/suite-run-config-load-once.test.ts
+++ b/tests/renderer/suite-run-config-load-once.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Issue #100, retest — "Save configuration" worked, restoring it did not.
+ *
+ * The reporter's three observations only look contradictory until you see the
+ * guard: leaving the Runner tab and coming back kept the config; opening the
+ * suite from the sidebar lost it; opening a request inside the suite and then
+ * returning to the Runner brought it back.
+ *
+ * The suite-items effect loads the saved config once per suite, tracked in a
+ * ref. It marked the suite as loaded BEFORE awaiting the config, and it took
+ * `runFolderName` as a dependency although it never reads it — and
+ * `runFolderName` is set from the session payload right after mount. So the
+ * first run was cancelled mid-await by its own dependency changing, the
+ * `if (cancelled) return` fired, and the ref was left claiming a config had
+ * been loaded that had never been applied. Every later run skipped the load.
+ * Only a remount (a detour through another tab) reset the ref — which is
+ * exactly the one path that worked.
+ *
+ * The ordering is what is pinned here: mark AFTER the load survives, never
+ * before.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parseSuiteRunConfig } from '../../src/renderer/lib/suite-run-config'
+
+const RUNNER_TAB = resolve(__dirname, '../../src/renderer/components/runner/RunnerTab.tsx')
+
+/**
+ * The load-once guard, reduced to the shape the component uses. The bug was
+ * an ordering one, so a faithful reduction reproduces it and the component's
+ * 1500 lines of unrelated wiring do not have to be mounted to see it.
+ */
+function makeLoader(opts: { markBeforeAwait: boolean }) {
+  const ref: { current: string | null } = { current: null }
+  const applied: string[] = []
+
+  async function run(
+    suiteId: string,
+    fetchConfig: () => Promise<string | null>,
+    signal: {
+      cancelled: boolean
+    },
+  ) {
+    if (ref.current === suiteId) return
+    if (opts.markBeforeAwait) ref.current = suiteId
+    const raw = await fetchConfig()
+    if (signal.cancelled) return
+    if (!opts.markBeforeAwait) ref.current = suiteId
+    const cfg = parseSuiteRunConfig(raw)
+    if (cfg) applied.push(suiteId)
+  }
+
+  return { run, applied, ref }
+}
+
+const CONFIG = JSON.stringify({
+  version: 1,
+  delay: 250,
+  iterationDelay: 0,
+  iterations: 3,
+  stopOnError: true,
+  persistResponses: false,
+  keepVariableValues: true,
+  environmentId: null,
+  items: [],
+})
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('the load-once guard (#100)', () => {
+  it('loses the config forever when the first run is cancelled — the reported bug', async () => {
+    const loader = makeLoader({ markBeforeAwait: true })
+    const first = { cancelled: false }
+    const inFlight = loader.run('suite-1', async () => CONFIG, first)
+    // `runFolderName` lands from the session payload → cleanup → re-run.
+    first.cancelled = true
+    await inFlight
+    await loader.run('suite-1', async () => CONFIG, { cancelled: false })
+
+    expect(loader.applied).toEqual([])
+    expect(loader.ref.current).toBe('suite-1') // marked, yet nothing applied
+  })
+
+  it('survives that cancellation once the mark comes after the load', async () => {
+    const loader = makeLoader({ markBeforeAwait: false })
+    const first = { cancelled: false }
+    const inFlight = loader.run('suite-1', async () => CONFIG, first)
+    first.cancelled = true
+    await inFlight
+    await loader.run('suite-1', async () => CONFIG, { cancelled: false })
+
+    expect(loader.applied).toEqual(['suite-1'])
+  })
+
+  it('still loads only once when nothing is cancelled', async () => {
+    const loader = makeLoader({ markBeforeAwait: false })
+    const quiet = { cancelled: false }
+    await loader.run('suite-1', async () => CONFIG, quiet)
+    await loader.run('suite-1', async () => CONFIG, quiet)
+
+    expect(loader.applied).toEqual(['suite-1'])
+  })
+
+  it('reloads when the tab is pointed at a different suite', async () => {
+    const loader = makeLoader({ markBeforeAwait: false })
+    const quiet = { cancelled: false }
+    await loader.run('suite-1', async () => CONFIG, quiet)
+    await loader.run('suite-2', async () => CONFIG, quiet)
+
+    expect(loader.applied).toEqual(['suite-1', 'suite-2'])
+  })
+})
+
+describe('RunnerTab keeps that ordering (#100)', () => {
+  const source = readFileSync(RUNNER_TAB, 'utf8')
+
+  it('marks the suite as loaded only after the cancellation check', () => {
+    const mark = source.indexOf('configLoadedForSuiteRef.current = suiteIdForRunner')
+    const guard = source.indexOf('if (configLoadedForSuiteRef.current !== suiteIdForRunner)')
+    const cancelCheck = source.indexOf('if (cancelled) return', guard)
+
+    expect(guard).toBeGreaterThan(-1)
+    expect(mark).toBeGreaterThan(cancelCheck)
+  })
+
+  it('does not depend on runFolderName, which it never reads', () => {
+    // The dependency was the churn the config load kept losing its race to.
+    expect(source).toContain('}, [suiteIdForRunner])')
+    expect(source).not.toContain('}, [suiteIdForRunner, runFolderName])')
+  })
+})

--- a/tests/renderer/workbench-empty-tab-strip.test.tsx
+++ b/tests/renderer/workbench-empty-tab-strip.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Issue #97, retest — the "+" was still gone after closing every tab.
+ *
+ * The first fix removed `if (tabs.length === 0) return null` from the strip
+ * itself, and `tab-strip-empty.test.tsx` renders `EndpointTabBar` directly, so
+ * it went green while the reported behaviour did not change at all: the
+ * workbench branch that ACTUALLY renders at zero tabs — the one showing
+ * PageWelcome — never mounted the strip in the first place. Twelve other
+ * branches did.
+ *
+ * So this test drives the workbench, not the strip: it asserts on what the
+ * user sees after closing the last tab, which is the only level at which the
+ * original report could have been verified.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- classic JSX runtime
+import * as React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { useTabsStore } from '../../src/renderer/stores/tabs.store'
+import type { Tab } from '../../src/renderer/types'
+
+vi.mock('../../src/renderer/lib/activate-tab', () => ({
+  activateTabStores: vi.fn(),
+  switchActiveTab: vi.fn(),
+}))
+vi.mock('../../src/renderer/components/shared/MonacoWrapperImpl', () => ({
+  default: () => null,
+}))
+
+// The workbench pulls in every editor and tool, several of which read their
+// IPC namespace at module scope. A permissive stub keeps the module graph
+// loadable without pretending any of it is exercised here.
+const anyApi: unknown = new Proxy(
+  {},
+  { get: () => new Proxy({}, { get: () => async () => ({ success: true, data: [] }) }) },
+)
+;(window as unknown as { api: unknown }).api = anyApi
+
+const Workbench = (await import('../../src/renderer/components/layout/Workbench')).default
+
+function tab(id: string): Tab {
+  return {
+    id,
+    name: id,
+    protocol: 'http',
+    method: 'GET',
+    url: '',
+    isDirty: false,
+    isLoading: false,
+  } as Tab
+}
+
+beforeEach(() => {
+  useTabsStore.setState({ tabs: [], activeTabId: null })
+})
+afterEach(cleanup)
+
+describe('the tab strip at zero tabs (#97)', () => {
+  it('still offers "+" when the last tab has been closed', () => {
+    render(<Workbench />)
+    expect(screen.getByTestId('tab-new')).toBeTruthy()
+  })
+
+  it('keeps the welcome surface as well — the two are not alternatives', () => {
+    render(<Workbench />)
+    // PageWelcome's protocol cards are the richer new-tab surface and were
+    // never the thing in question; the report was that the affordance the user
+    // had just been clicking disappeared alongside them.
+    expect(screen.getByTestId('tab-new')).toBeTruthy()
+    expect(document.body.textContent).toBeTruthy()
+  })
+
+  it('survives Force Close All Tabs, which is how the reporter got there', () => {
+    useTabsStore.setState({ tabs: [tab('a'), tab('b')], activeTabId: 'a' })
+    const { rerender } = render(<Workbench />)
+    expect(screen.getByTestId('tab-new')).toBeTruthy()
+
+    useTabsStore.getState().closeAllTabs()
+    rerender(<Workbench />)
+
+    expect(useTabsStore.getState().tabs).toHaveLength(0)
+    expect(screen.getByTestId('tab-new')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Three issues were retested on `e8cd612` and all three still reproduced. Each fix had stopped one step short of the path the reporter was actually on.

## issue #97 — the "+" still vanished with the last tab

The first fix removed `if (tabs.length === 0) return null` from `EndpointTabBar`. That was necessary and not sufficient: the workbench branch that renders in exactly that state — the one showing `PageWelcome` — never mounted the strip at all. Twelve other branches did.

`tab-strip-empty.test.tsx` renders `EndpointTabBar` directly, which is why it went green against a behaviour that had not changed. The new test drives `Workbench` and asserts on what the user sees after closing the last tab, including via Force Close All Tabs — the route the reporter took.

## issue #112 — response survived tab switching, not a second click in the tree

The first fix removed the stray `clearResponse()` from the strip's switch and close handlers. The tree is a second navigation path into the same tab, and it does something the strip never did: it re-opens the request. `openPreviewTab` recognises an already-open endpoint and **activates** it rather than minting a second tab — so the `clearResponse()` and DB re-hydrate that follow every open landed on live state, and the response the user had just received was gone.

Every open path now asks `focusOpenTabFor` first. An open tab is the newer state, unsaved edits included; the DB copy is not. Putting the gate in the shared helper also covers opening a request from a runner result row, which had the same defect and would have been reported next.

## issue #100 — saved run configuration returned only after a detour

The reporter's three observations look contradictory until the guard is visible: leaving the Runner tab and returning kept the config; opening the suite from the sidebar lost it; opening a request inside the suite and then returning brought it back.

The suite-items effect loads the saved config once per suite, tracked in a ref. It marked the suite as loaded **before** awaiting the config, so a cancelled effect left the suite flagged as loaded with nothing applied, and every later run skipped the load — only a remount reset the ref, which is precisely the one path that worked. The effect also took `runFolderName` as a dependency without ever reading it, and that value is set from the session payload right after mount: the churn the load kept losing its race to.

Marked after the load survives; the spurious dependency dropped.

---

**Tests:** `workbench-empty-tab-strip` (3), `focus-open-tab` (7), `suite-run-config-load-once` (6). Each was proven to fail before its fix and pass after. Full unit suite 3658 green; typecheck and lint clean.

**Note on #97:** it was originally closed as invalid on the grounds that `PageWelcome` is the richer new-tab surface, then reopened. The two are not alternatives — the strip now sits above the welcome cards, so both are present.

Fixes reported in issue #97, issue #100 and issue #112.
