### PR TITLE
fix: stop three kinds of cross-project bleed

### DIFF
--- a/src/main/mock/server.ts
+++ b/src/main/mock/server.ts
@@ -140,9 +140,22 @@ class MockServerManager extends EventEmitter {
         s.def.host === def.host &&
         (s.status === 'running' || s.status === 'starting')
       ) {
+        /*
+         * This manager is process-global: it holds the running servers of
+         * EVERY project, and nothing stops another project's servers when the
+         * user switches. The message used to say "in this project", which sent
+         * the user looking through the current project for a server that is
+         * not there — the port is held by one they cannot see from here.
+         */
+        const sameProject =
+          (s.def.projectId ?? null) === (def.projectId ?? null) || !s.def.projectId
         return {
           ok: false,
-          error: `Port ${def.port} is already in use by another mock server in this project`,
+          error: sameProject
+            ? `Port ${def.port} is already in use by mock server "${s.def.name}" in this project`
+            : `Port ${def.port} is already in use by mock server "${s.def.name}", which belongs to ` +
+              'another project. Mock servers keep running when you switch projects — stop it there, ' +
+              'or use a different port.',
         }
       }
     }

--- a/src/main/protocols/http.engine.ts
+++ b/src/main/protocols/http.engine.ts
@@ -338,7 +338,26 @@ interface CachedOAuth2Token {
 // OAuth2 vs hand-scripting a token-fetch request.
 const oauth2TokenCache = new Map<string, CachedOAuth2Token>()
 
-function oauth2CacheKey(o: OAuth2GrantConfig): string {
+/**
+ * Identity of a cached token.
+ *
+ * The secret half of the credentials belongs in here as much as the public
+ * half: same token URL, same client id, different secret is one client's
+ * token being handed to another caller. That happens for real when two
+ * projects target the same identity provider with the same client id and a
+ * per-tenant secret, and on any secret rotation — where the stale token would
+ * otherwise keep being served for the rest of its lifetime (an hour by
+ * default). Same reasoning for the password grant: `username` was keyed,
+ * `password` was not.
+ *
+ * Hashed rather than stored: this key lives in a long-lived in-process Map,
+ * and there is no reason for a plaintext secret to sit in it when a digest
+ * distinguishes credentials just as well.
+ */
+export function oauth2CacheKey(o: OAuth2GrantConfig): string {
+  const secrets = createHash('sha256')
+    .update(`${o.clientSecret ?? ''}\u0000${o.password ?? ''}`)
+    .digest('hex')
   return JSON.stringify({
     t: o.tokenUrl ?? '',
     c: o.clientId ?? '',
@@ -346,6 +365,7 @@ function oauth2CacheKey(o: OAuth2GrantConfig): string {
     g: o.grantType ?? 'client_credentials',
     u: o.username ?? '',
     a: o.clientAuth ?? 'header',
+    k: secrets,
   })
 }
 

--- a/src/renderer/components/runner/RunnerTab.tsx
+++ b/src/renderer/components/runner/RunnerTab.tsx
@@ -14,6 +14,7 @@ import RunnerSequence from './RunnerSequence'
 import RunnerConfig, { type SchedulePayload } from './RunnerConfig'
 import RunnerResults from './RunnerResults'
 import { openEndpointTab, openSuiteItemTab } from '../../lib/open-endpoint-tab'
+import { runnerKey } from '../../lib/runner-storage'
 import { saveDirtyRunItemsBeforeRun } from '../../lib/dirty-run-guard'
 import { useUIStore } from '../../stores/ui.store'
 import { toast } from '../../lib/toast'
@@ -244,7 +245,7 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
   // bounce the user back to "config" (v1.3.1 §5.11 E11). The key intentionally
   // mirrors the runner-report sessionStorage prefix so cleanup stays local
   // to RunnerTab.
-  const viewStorageKey = tabId ? `runner-view-${tabId}` : null
+  const viewStorageKey = runnerKey('view', tabId)
   // Set when this tab was opened by an entry point that explicitly asked for the
   // run config without a suite/folder scope (the Command Palette's "Open
   // collection runner"). It lets the config screen survive a remount without
@@ -264,7 +265,8 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
       // 'home' so the user lands on the curated Tests overview instead.
       if (stored === 'config') {
         try {
-          const sess = tabId ? sessionStorage.getItem(`runner-report-${tabId}`) : null
+          const reportKey = runnerKey('report', tabId)
+          const sess = reportKey ? sessionStorage.getItem(reportKey) : null
           const data = sess ? (JSON.parse(sess) as { sourceType?: string; suiteId?: string }) : null
           const hasSuiteScope = data?.sourceType === 'suite' && typeof data.suiteId === 'string'
           if (hasSuiteScope || folderId) return 'config'
@@ -369,7 +371,7 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
   // happens exactly once, on first mount. An IIFE at component scope would
   // re-run on every render and do an MB-scale JSON.parse per re-render for
   // big runs.
-  const runDataStorageKey = tabId ? `runner-run-data-${tabId}` : null
+  const runDataStorageKey = runnerKey('run-data', tabId)
   const readStoredRunData = (): {
     results: EndpointRunResult[]
     report: RunnerReport | null
@@ -401,7 +403,7 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
   // tab (or switching between Overview / All Runs and back to a results
   // view) does not drop the user back to an unscoped blank state
   // (v1.4.2 T-5.6, T-12.5).
-  const resultsStorageKey = tabId ? `runner-results-${tabId}` : null
+  const resultsStorageKey = runnerKey('results', tabId)
   const [selectedResultId, setSelectedResultId] = useState<string | null>(() => {
     if (!resultsStorageKey) return null
     try {
@@ -479,7 +481,8 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
   const [suiteFilterIds, setSuiteFilterIds] = useState<Set<string> | null>(() => {
     if (!tabId) return null
     try {
-      const stored = sessionStorage.getItem(`runner-report-${tabId}`)
+      const reportKey = runnerKey('report', tabId)
+      const stored = reportKey ? sessionStorage.getItem(reportKey) : null
       if (!stored) return null
       const data = JSON.parse(stored) as {
         sourceType?: string
@@ -503,7 +506,8 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
   const [suiteIdForRunner, setSuiteIdForRunner] = useState<string | null>(() => {
     if (!tabId) return null
     try {
-      const stored = sessionStorage.getItem(`runner-report-${tabId}`)
+      const reportKey = runnerKey('report', tabId)
+      const stored = reportKey ? sessionStorage.getItem(reportKey) : null
       if (!stored) return null
       const data = JSON.parse(stored) as { sourceType?: string; suiteId?: string }
       if (data.sourceType === 'suite' && typeof data.suiteId === 'string') {
@@ -549,7 +553,8 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
    */
   useEffect(() => {
     if (!tabId) return
-    const stored = sessionStorage.getItem(`runner-report-${tabId}`)
+    const reportKey = runnerKey('report', tabId)
+    const stored = reportKey ? sessionStorage.getItem(reportKey) : null
     if (!stored) return
 
     let data: {
@@ -599,7 +604,7 @@ export default function RunnerTab({ folderId, tabId, sessionKey }: RunnerTabProp
     // back over the new ones on the next tab switch.
 
     // ─── INTENT — once per session token ───
-    const spentKey = `runner-report-spent-${tabId}`
+    const spentKey = runnerKey('report-spent', tabId) ?? ''
     const token = sessionKey ?? ''
     if (sessionStorage.getItem(spentKey) === token) return
     sessionStorage.setItem(spentKey, token)

--- a/src/renderer/lib/open-runner-tab.ts
+++ b/src/renderer/lib/open-runner-tab.ts
@@ -6,6 +6,7 @@
 import { useTabsStore } from '../stores/tabs.store'
 import { useUIStore } from '../stores/ui.store'
 import { isRunnerBusy } from './runner-activity'
+import { runnerKey } from './runner-storage'
 
 const RUNNER_TAB_ID = 'runner-main'
 
@@ -30,7 +31,8 @@ export function openOrReuseRunnerTab(
   const sessionKey = nextSessionKey()
 
   if (sessionData) {
-    sessionStorage.setItem(`runner-report-${tabId}`, JSON.stringify(sessionData))
+    const reportKey = runnerKey('report', tabId)
+    if (reportKey) sessionStorage.setItem(reportKey, JSON.stringify(sessionData))
   }
 
   // A scopeless runner tab lands on the Tests overview by design — dropping
@@ -41,7 +43,8 @@ export function openOrReuseRunnerTab(
   // other way to reach a project-wide run config. `config-explicit` is a
   // distinct sentinel so the scope guard on plain `config` is untouched.
   if (opts?.view === 'config') {
-    sessionStorage.setItem(`runner-view-${tabId}`, 'config-explicit')
+    const viewKey = runnerKey('view', tabId)
+    if (viewKey) sessionStorage.setItem(viewKey, 'config-explicit')
   }
 
   if (existing) {
@@ -67,15 +70,18 @@ export function openFolderRunner(folderId: string, folderName?: string): void {
   // this the folder runner opened on the generic Overview instead of a run
   // scoped to the folder (#39). RunnerTab's view initializer restores 'config'
   // when this key is set AND the tab carries a folder scope.
-  sessionStorage.setItem(`runner-view-${tabId}`, 'config')
+  const viewKey = runnerKey('view', tabId)
+  if (viewKey) sessionStorage.setItem(viewKey, 'config')
   // Re-arming this tab means "here is the next run", so the previous one's
   // stored report goes with it. RunnerTab keeps that report so a tab switch
   // can put the results back (issue #93); left behind here it would come back
   // instead of the Start-run screen, which is issue #66 in reverse. A folder
   // runner's scope travels on `tab.folderId`, so nothing else in the payload
   // is worth keeping.
-  sessionStorage.removeItem(`runner-report-${tabId}`)
-  sessionStorage.removeItem(`runner-report-spent-${tabId}`)
+  const staleReport = runnerKey('report', tabId)
+  const staleSpent = runnerKey('report-spent', tabId)
+  if (staleReport) sessionStorage.removeItem(staleReport)
+  if (staleSpent) sessionStorage.removeItem(staleSpent)
   if (isRunnerBusy(tabId)) {
     // That tab's run is still executing. Re-arming would remount it and take
     // the live progress + Cancel button away while main keeps running — focus

--- a/src/renderer/lib/runner-storage.ts
+++ b/src/renderer/lib/runner-storage.ts
@@ -1,0 +1,44 @@
+/**
+ * Session-storage keys for the runner tab — built in ONE place, and always
+ * scoped to a project.
+ *
+ * The shared runner tab is a singleton by design: `openOrReuseRunnerTab` puts
+ * every entry point (Tests panel, Tests welcome, history, scheduled tasks) on
+ * one tab called `runner-main`. Tabs themselves are per-project — the workspace
+ * store swaps each project's set on switch — but the id is a constant, so two
+ * projects' runner tabs were the SAME id, and every key derived from it was
+ * therefore shared between them. Nothing cleaned up: `replaceAllTabs` only
+ * swaps the array, `cleanupTabState` never touched sessionStorage, and the
+ * re-arm effect sets the view without clearing results.
+ *
+ * The visible consequence was one project's run results, report and suite
+ * scope showing up in another project's Runner. Scoping the keys fixes it at
+ * the level where the collision actually happens; the tab id can stay the
+ * singleton it is meant to be.
+ *
+ * Both the writer (`open-runner-tab.ts`) and the reader (`RunnerTab.tsx`) go
+ * through here — a second place building these strings by hand is how the two
+ * sides drift apart, and a key that only one side scopes reads as "state
+ * silently lost" instead.
+ */
+import { useWorkspaceStore } from '../stores/workspace.store'
+
+export type RunnerStorageKind = 'report' | 'report-spent' | 'view' | 'run-data' | 'results'
+
+/**
+ * Project used for scoping. `none` covers the Home screen, where no project is
+ * active — a real project id never collides with it.
+ */
+function activeProjectScope(): string {
+  return useWorkspaceStore.getState().activeProjectId ?? 'none'
+}
+
+/**
+ * `null` when there is no tab to scope to, so callers keep their existing
+ * "no tab, no storage" branches instead of writing to a key with `undefined`
+ * baked into it.
+ */
+export function runnerKey(kind: RunnerStorageKind, tabId: string | undefined): string | null {
+  if (!tabId) return null
+  return `runner-${kind}-${activeProjectScope()}-${tabId}`
+}

--- a/tests/main/mock-port-conflict-message.test.ts
+++ b/tests/main/mock-port-conflict-message.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Multi-project isolation — the mock-server port conflict named the wrong
+ * project.
+ *
+ * `mockServerManager` is a process-global singleton holding the running
+ * servers of EVERY project, and nothing stops another project's servers when
+ * the user switches (`stopAll` exists but is never called — mocks are meant to
+ * keep serving). The pre-bind check therefore fires across projects, but its
+ * message said the port was taken "in this project", sending the user to look
+ * through the current project for a server that is not there.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { mockServerManager, type MockServerDef } from '../../src/main/mock/server'
+
+function def(over: Partial<MockServerDef>): MockServerDef {
+  return {
+    id: 'srv-1',
+    name: 'Mock',
+    host: '127.0.0.1',
+    port: 0,
+    basePath: '',
+    cors: { enabled: false } as MockServerDef['cors'],
+    auth: { type: 'none' } as MockServerDef['auth'],
+    failure: {} as MockServerDef['failure'],
+    rateLimit: {} as MockServerDef['rateLimit'],
+    echoEnabled: false,
+    proxyEnabled: false,
+    proxyTarget: '',
+    proxyRecord: false,
+    endpoints: [],
+    ...over,
+  } as MockServerDef
+}
+
+/** A free port, so the suite never depends on one being available. */
+async function freePort(): Promise<number> {
+  const net = await import('node:net')
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer()
+    srv.on('error', reject)
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address()
+      const port = typeof addr === 'object' && addr ? addr.port : 0
+      srv.close(() => resolve(port))
+    })
+  })
+}
+
+afterEach(async () => {
+  await mockServerManager.stopAll()
+})
+
+describe('port already taken by another project', () => {
+  it('says so, instead of blaming the project the user is looking at', async () => {
+    const port = await freePort()
+    const first = await mockServerManager.start(
+      def({ id: 'srv-a', name: 'Orders mock', port, projectId: 'proj-a' }),
+    )
+    expect(first.ok).toBe(true)
+
+    const second = await mockServerManager.start(
+      def({ id: 'srv-b', name: 'Billing mock', port, projectId: 'proj-b' }),
+    )
+
+    expect(second.ok).toBe(false)
+    if (second.ok) return
+    expect(second.error).toContain('another project')
+    expect(second.error).toContain('Orders mock')
+    expect(second.error).not.toContain('in this project')
+  })
+
+  it('still says "in this project" when it really is this project', async () => {
+    const port = await freePort()
+    await mockServerManager.start(def({ id: 'srv-a', name: 'Orders mock', port, projectId: 'p' }))
+    const second = await mockServerManager.start(
+      def({ id: 'srv-b', name: 'Billing mock', port, projectId: 'p' }),
+    )
+
+    expect(second.ok).toBe(false)
+    if (second.ok) return
+    expect(second.error).toContain('in this project')
+  })
+})

--- a/tests/main/oauth2-cache-key.test.ts
+++ b/tests/main/oauth2-cache-key.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Multi-project isolation — the OAuth 2.0 token cache keyed the public half of
+ * the credentials and not the secret half.
+ *
+ * `tokenUrl + clientId + scope + grantType + username + clientAuth` identified
+ * a cached token; `clientSecret` and (for the password grant) `password` did
+ * not take part. Two projects pointing at the same identity provider with the
+ * same client id and a per-tenant secret therefore shared one token, and any
+ * secret rotation kept serving the token minted with the old one until it
+ * expired — an hour by default.
+ *
+ * `{{variables}}` are resolved before the engine sees this config, so keys do
+ * differ whenever the URL or client id come from an environment. The gap was
+ * specifically the case where only the secret differs.
+ */
+import { describe, it, expect } from 'vitest'
+import { oauth2CacheKey, type OAuth2GrantConfig } from '../../src/main/protocols/http.engine'
+
+function config(over: Partial<OAuth2GrantConfig> = {}): OAuth2GrantConfig {
+  return {
+    grantType: 'client_credentials',
+    tokenUrl: 'https://idp.example.test/oauth2/token',
+    clientId: 'testnizer',
+    clientSecret: 'secret-a',
+    scope: 'read',
+    clientAuth: 'header',
+    ...over,
+  } as OAuth2GrantConfig
+}
+
+describe('oauth2 cache identity', () => {
+  it('separates two callers that differ only by client secret', () => {
+    expect(oauth2CacheKey(config())).not.toBe(oauth2CacheKey(config({ clientSecret: 'secret-b' })))
+  })
+
+  it('separates two password-grant callers that differ only by password', () => {
+    const base = config({ grantType: 'password', username: 'ncetinkaya', password: 'one' })
+    expect(oauth2CacheKey(base)).not.toBe(oauth2CacheKey({ ...base, password: 'two' }))
+  })
+
+  it('treats a rotated secret as a different token, not the same one', () => {
+    const before = oauth2CacheKey(config({ clientSecret: 'old' }))
+    const after = oauth2CacheKey(config({ clientSecret: 'new' }))
+    expect(before).not.toBe(after)
+  })
+
+  it('still reuses the cache for an identical configuration', () => {
+    expect(oauth2CacheKey(config())).toBe(oauth2CacheKey(config()))
+  })
+
+  it('keeps separating the fields it always did', () => {
+    const base = oauth2CacheKey(config())
+    for (const over of [
+      { tokenUrl: 'https://other.example.test/token' },
+      { clientId: 'other' },
+      { scope: 'write' },
+      { clientAuth: 'body' as const },
+    ]) {
+      expect(oauth2CacheKey(config(over)), JSON.stringify(over)).not.toBe(base)
+    }
+  })
+
+  it('does not carry the secret in plaintext — the key lives in a long-lived map', () => {
+    const key = oauth2CacheKey(config({ clientSecret: 'super-secret-value' }))
+    expect(key).not.toContain('super-secret-value')
+  })
+
+  it('handles a missing secret without collapsing onto a set one', () => {
+    expect(oauth2CacheKey(config({ clientSecret: undefined }))).not.toBe(
+      oauth2CacheKey(config({ clientSecret: '' + 'x' })),
+    )
+  })
+})

--- a/tests/renderer/folder-runner-page.test.ts
+++ b/tests/renderer/folder-runner-page.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
+import { runnerKey } from '../../src/renderer/lib/runner-storage'
 import { openFolderRunner } from '../../src/renderer/lib/open-runner-tab'
 import { useTabsStore } from '../../src/renderer/stores/tabs.store'
 import { useUIStore } from '../../src/renderer/stores/ui.store'
@@ -38,7 +39,7 @@ describe('openFolderRunner — page navigation (#39)', () => {
     // folder. RunnerTab restores 'config' from this key when the tab has a
     // folder scope.
     openFolderRunner('folder-1', 'My Folder')
-    expect(sessionStorage.getItem('runner-view-runner-folder-1')).toBe('config')
+    expect(sessionStorage.getItem(runnerKey('view', 'runner-folder-1') as string)).toBe('config')
   })
 
   it('falls back to a generic name when none is given', () => {

--- a/tests/renderer/runner-storage-project-scope.test.ts
+++ b/tests/renderer/runner-storage-project-scope.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Multi-project isolation — the Runner tab leaked one project's run into
+ * another's.
+ *
+ * `openOrReuseRunnerTab` puts every entry point on a single shared tab whose
+ * id is the constant `runner-main`. Tab SETS are per project (the workspace
+ * store swaps them on switch), but the id is not, so every sessionStorage key
+ * derived from it — run results, report, suite scope, view — was shared
+ * between projects. Nothing cleaned it up: `replaceAllTabs` only swaps the
+ * array, `cleanupTabState` never touched sessionStorage, and the re-arm effect
+ * sets the view without clearing results. Run a suite in project A, switch to
+ * project B, open the Runner: A's results were sitting there.
+ *
+ * Keys are now built in one place and carry the project.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkspaceStore } from '../../src/renderer/stores/workspace.store'
+import { runnerKey } from '../../src/renderer/lib/runner-storage'
+
+const RUNNER_TAB = 'runner-main'
+
+function inProject(id: string | null): void {
+  useWorkspaceStore.setState({ activeProjectId: id })
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  inProject(null)
+})
+
+describe('runner storage keys carry the project', () => {
+  it('gives two projects different keys for the SAME tab id', () => {
+    inProject('proj-a')
+    const a = runnerKey('run-data', RUNNER_TAB)
+    inProject('proj-b')
+    const b = runnerKey('run-data', RUNNER_TAB)
+
+    expect(a).toBeTruthy()
+    expect(a).not.toBe(b)
+  })
+
+  it('keeps every kind separated the same way', () => {
+    const kinds = ['report', 'report-spent', 'view', 'run-data', 'results'] as const
+    inProject('proj-a')
+    const a = kinds.map((k) => runnerKey(k, RUNNER_TAB))
+    inProject('proj-b')
+    const b = kinds.map((k) => runnerKey(k, RUNNER_TAB))
+
+    expect(new Set([...a, ...b]).size).toBe(kinds.length * 2)
+  })
+
+  it('is stable for the same project and tab', () => {
+    inProject('proj-a')
+    expect(runnerKey('results', RUNNER_TAB)).toBe(runnerKey('results', RUNNER_TAB))
+  })
+
+  it('scopes the Home screen, where no project is active, without colliding', () => {
+    inProject(null)
+    const home = runnerKey('run-data', RUNNER_TAB)
+    inProject('proj-a')
+    expect(home).not.toBe(runnerKey('run-data', RUNNER_TAB))
+  })
+
+  it('returns null with no tab, so callers keep their no-storage branch', () => {
+    inProject('proj-a')
+    expect(runnerKey('run-data', undefined)).toBeNull()
+    expect(runnerKey('run-data', '')).toBeNull()
+  })
+
+  it('still separates two runner tabs within one project (folder runners)', () => {
+    inProject('proj-a')
+    expect(runnerKey('run-data', 'runner-folder-1')).not.toBe(
+      runnerKey('run-data', 'runner-folder-2'),
+    )
+  })
+})
+
+describe('the reported leak', () => {
+  it("does not serve project A's stored run to project B", () => {
+    inProject('proj-a')
+    const write = runnerKey('run-data', RUNNER_TAB)
+    expect(write).toBeTruthy()
+    sessionStorage.setItem(write as string, JSON.stringify({ results: ['A-run'], report: null }))
+
+    // Switching projects swaps the tab set; the runner tab keeps its id.
+    inProject('proj-b')
+    const read = runnerKey('run-data', RUNNER_TAB)
+    expect(sessionStorage.getItem(read as string)).toBeNull()
+
+    // ...and A's run is still there when the user goes back.
+    inProject('proj-a')
+    expect(sessionStorage.getItem(runnerKey('run-data', RUNNER_TAB) as string)).toContain('A-run')
+  })
+})

--- a/tests/renderer/runner-tab-reuse.test.tsx
+++ b/tests/renderer/runner-tab-reuse.test.tsx
@@ -11,6 +11,7 @@
  * These tests drive the REAL Workbench so the keying itself is under test.
  */
 import * as React from 'react'
+import { runnerKey } from '../../src/renderer/lib/runner-storage'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, act } from '@testing-library/react'
 
@@ -114,9 +115,9 @@ function seedFinishedRun(tabId: string): void {
     },
   ]
   report.results = results
-  sessionStorage.setItem(`runner-view-${tabId}`, 'results')
+  sessionStorage.setItem(runnerKey('view', tabId) as string, 'results')
   sessionStorage.setItem(
-    `runner-run-data-${tabId}`,
+    runnerKey('run-data', tabId) as string,
     JSON.stringify({ results, report, startedAt: 1 }),
   )
 }

--- a/tests/renderer/tests-module-tabs.test.tsx
+++ b/tests/renderer/tests-module-tabs.test.tsx
@@ -17,6 +17,7 @@
  * happens between components rather than inside one.
  */
 import * as React from 'react'
+import { runnerKey } from '../../src/renderer/lib/runner-storage'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, act, fireEvent } from '@testing-library/react'
 
@@ -62,9 +63,7 @@ function suiteApi() {
         Promise.resolve({
           success: true,
           data: {
-            items: [
-              { id: 'item-1', name: SUITE_ITEM, method: 'GET', url: '/s', folder_id: null },
-            ],
+            items: [{ id: 'item-1', name: SUITE_ITEM, method: 'GET', url: '/s', folder_id: null }],
             folders: [],
           },
         }),
@@ -157,7 +156,7 @@ describe('a suite runner tab survives a trip to another tab (#93 B)', () => {
     })
 
     const tabId = useTabsStore.getState().activeTabId!
-    const stored = sessionStorage.getItem(`runner-report-${tabId}`)
+    const stored = sessionStorage.getItem(runnerKey('report', tabId) as string)
     expect(stored).toBeTruthy()
     expect(JSON.parse(stored!).suiteId).toBe('suite-1')
   })


### PR DESCRIPTION
An audit of what a second open project could disturb, and fixes for the three things it found.

**The data layer was already right.** Environments (including which one is active), certificates, history, mock server rows and scheduled tasks all filter by project, `loadEnvVars` resolves variables inside a project scope, and the history panel refetches when the project changes. Child tables without a `project_id` reach it through their parent, which is the correct shape. Nothing to change there.

What leaked was the two layers that do not know projects exist: the renderer's persisted state, and the main process's global caches.

## Runner tab — one project's run showing in another

`openOrReuseRunnerTab` deliberately puts every entry point (Tests panel, Tests welcome, history, scheduled tasks) on a single shared tab whose id is the constant `runner-main`. Tab *sets* are per project — the workspace store swaps them on switch — but the id is not, so every `sessionStorage` key derived from it was shared between projects: run results, report, suite scope, view.

Nothing cleaned it up. `replaceAllTabs` only swaps the array, `cleanupTabState` never touched `sessionStorage`, `openFolderRunner` clears the report key but not the run-data one, and the re-arm effect sets the view without clearing results. Run a suite in project A, switch to project B, open the Runner: A's results were sitting there.

Keys are now built in one place (`lib/runner-storage.ts`) and carry the project. The tab id stays the singleton it is meant to be — the collision is at the storage layer, so that is where it is fixed. In-memory state was already safe: the `key` prop added for issue #66 forces a remount on every open.

## Mock server port conflict — the message named the wrong project

`mockServerManager` is a process-global singleton holding the running servers of every project, and nothing stops another project's servers on switch (`stopAll` exists and is never called — mocks are meant to keep serving). The pre-bind check therefore fires across projects, but its message said the port was taken *"in this project"*, sending the user through the current project looking for a server that is not there.

It now names the server and says which side of the fence it is on.

## OAuth 2.0 token cache — the secret was not part of the token's identity

The cache key carried `tokenUrl + clientId + scope + grantType + username + clientAuth`. `clientSecret` and, for the password grant, `password` did not take part. So the same token URL with the same client id and a *different secret* shared one token — real when two projects target one corporate identity provider with a per-tenant secret, and on every secret rotation, where the token minted with the old secret kept being served for the rest of its lifetime (an hour by default).

`{{variables}}` are resolved before the engine sees the config, so keys already differ whenever the URL or client id come from an environment; the gap was specifically the case where only the secret differs. It is hashed into the key rather than stored, since the key lives in a long-lived in-process map.

---

**Tests:** `runner-storage-project-scope` (7), `oauth2-cache-key` (7), `mock-port-conflict-message` (2). Each was proven to fail before its fix and pass after. Three existing runner tests built these storage keys by hand — the drift the helper exists to prevent — and now go through it. Full unit suite 3674 green; typecheck and lint clean.
